### PR TITLE
feat: add rate limiting middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 
 # Set environment variables
 ENV WAR_ID="801"
+ENV RATE_LIMIT="200"
 ENV DATABASE_URL="file:./database/data.db"
 ENV API_URL="https://api.live.prod.thehelldiversgame.com/api"
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@
 
 The unofficial API was not explicitly made usable by Arrowhead Game Studios for third parties, may be subject to change at any time. This API will be updated to reflect any changes to the game API.
 
-## How does it work?
+### How does it work?
 
 The API is written in Typescript and runs on the Bun framework. It pulls data from the Helldivers 2 API and transforms it into a more user-friendly format. It also caches the data so that the app can pull data from the API without having to worry about rate limits or slow response times.
+
+## Rate limit
+
+The Helldivers Companion API has a rate limit of 200 requests per minute.To avoid hitting rate limits in your clients check the following headers in your response:
+
+- `X-Rate-Limit`: The maximum number of requests per minute.
+- `X-Rate-Count`: The number of requests made in the current minute.
+- `X-Rate-Reset`: The time at which the current rate limit resets.
+- `X-Rate-Remaining`: The number of requests remaining.
 
 ## API Entities and Endpoints
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The API is written in Typescript and runs on the Bun framework. It pulls data fr
 
 ## Rate limit
 
-The Helldivers Companion API has a rate limit of 200 requests per minute.To avoid hitting rate limits in your clients check the following headers in your response:
+The Helldivers Companion API has a rate limit of 200 requests per minute. To avoid hitting rate limits in your clients check the following headers in your response:
 
 - `X-Rate-Limit`: The maximum number of requests per minute.
 - `X-Rate-Count`: The number of requests made in the current minute.

--- a/postman.json
+++ b/postman.json
@@ -1,13 +1,14 @@
 {
 	"info": {
 		"_postman_id": "92940ded-affa-4260-a27b-f12888c76b5d",
-		"name": "Helldivers 2",
+		"name": "Helldivers Companion API",
+		"description": "## Whats is the Helldivers Companion API?\n\nThe API is written in Typescript and runs on the Bun framework. It pulls data from the Helldivers 2 API and transforms it into a more user-friendly format. It also caches the data so that the app can pull data from the API without having to worry about rate limits or slow response times.\n\n## Statement\n\nThe unofficial API was not explicitly made usable by Arrowhead Game Studios for third parties, may be subject to change at any time. This API will be updated to reflect any changes to the game API.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "6421438"
 	},
 	"item": [
 		{
-			"name": "source",
+			"name": "Source",
 			"item": [
 				{
 					"name": "Get War Status",
@@ -74,7 +75,7 @@
 			]
 		},
 		{
-			"name": "sectors",
+			"name": "Sectors",
 			"item": [
 				{
 					"name": "/api/sectors",
@@ -609,7 +610,7 @@
 			"description": "Sectors contain a number of planets and define a area on the galaxy map. At the moment we are missing some data for the sectors, but we will add them as soon as we have them."
 		},
 		{
-			"name": "planets",
+			"name": "Planets",
 			"item": [
 				{
 					"name": "/api/planets",
@@ -1389,10 +1390,10 @@
 					]
 				}
 			],
-			"description": "Planets celestial bodies inside a sector. As the war for democracy rages on, the planets are the main battlegrounds. Planets have player counts, a controlling faction."
+			"description": "Celestial bodies inside a sector. As the war for democracy rages on, the planets are the main battlegrounds. Planets carry player counts and have a controlling faction."
 		},
 		{
-			"name": "attacks",
+			"name": "Attacks",
 			"item": [
 				{
 					"name": "/api/attacks",
@@ -2059,7 +2060,7 @@
 			"description": "Attacks always have a source and a target. The source is the planet that the attack is coming from, and the target is the planet that the attack is going to. You an check the attack progress by having a look on the planet's health properties."
 		},
 		{
-			"name": "factions",
+			"name": "Factions",
 			"item": [
 				{
 					"name": "/api/factions",
@@ -2869,7 +2870,7 @@
 			"description": "Factions are divided in three groups: Terminids, Humans and Automatons. Humans are the only faction that can be controlled by players. The other two are controlled by the game as Non-Player Characters (NPCs)."
 		},
 		{
-			"name": "war",
+			"name": "War",
 			"item": [
 				{
 					"name": "/api/war",
@@ -2893,7 +2894,7 @@
 			"description": "The current war season is the 1st. The war season is a period of time in which the factions fight for control of the planets. The war season has a start and an end date which of the time of this writing is bugged out and not working properly."
 		},
 		{
-			"name": "events",
+			"name": "Events",
 			"item": [
 				{
 					"name": "/api/events",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ import "jobs/refresh";
 
 import { Hono } from "hono";
 
+import cache from "middleware/cache";
+import rateLimit from "middleware/rate-limit";
+
 import wars from "routes/war";
 import events from "routes/events";
-import cache from "middleware/cache";
 import planets from "routes/planets";
 import sectors from "routes/sectors";
 import attacks from "routes/attacks";
@@ -12,6 +14,7 @@ import factions from "routes/factions";
 
 // initiate hono api
 const app = new Hono().basePath("/api");
+app.use(rateLimit);
 app.use(cache);
 
 // routes for the api

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,0 +1,56 @@
+import Cache from "memory-cache";
+import type { Context, Next } from "hono";
+
+const RATE_LIMIT = parseInt(process.env.RATE_LIMIT || "60");
+
+interface RateLimit {
+  count: number;
+  reset: number;
+  limit: number;
+  remaining: number;
+}
+
+export default async function rateLimit(ctx: Context, next: Next) {
+  const ip = ctx.req.header("X-Forwarded-For") || ctx.req.header("X-Real-IP");
+  const key = `rate-limit:${ip ?? "unknown"}`;
+  const rl: RateLimit = Cache.get(key);
+
+  const now = Date.now();
+  const reset = now + 1000 * 60;
+
+  ctx.res.headers.set("X-Rate-Limit", `${RATE_LIMIT}`);
+  ctx.res.headers.set("X-Rate-Count", `${rl?.count ?? 1}`);
+  ctx.res.headers.set("X-Rate-Reset", `${rl?.reset ?? reset}`);
+  ctx.res.headers.set("X-Rate-Remaining", `${rl?.remaining ?? RATE_LIMIT}`);
+
+  if (!rl) {
+    const payload: RateLimit = {
+      count: 1,
+      reset: reset,
+      limit: RATE_LIMIT,
+      remaining: RATE_LIMIT - 1,
+    };
+
+    Cache.put(key, payload, 1000 * 60);
+    return await next();
+  }
+
+  if (rl.count < RATE_LIMIT) {
+    const payload: RateLimit = {
+      ...rl,
+      count: rl.count + 1,
+      remaining: rl.limit - (rl.count + 1),
+    };
+
+    Cache.put(key, payload, 1000 * 60);
+    return await next();
+  }
+
+  ctx.status(429);
+  return ctx.json({
+    data: null,
+    error: {
+      details: ["Rate limit exceeded"],
+    },
+  });
+}


### PR DESCRIPTION
## Description

This PR introduces new rate limiting logic for the API. The Helldivers Companion API has a rate limit of 200 requests per minute. To avoid hitting rate limits in your clients check the following headers in your response:

- `X-Rate-Limit`: The maximum number of requests per minute.
- `X-Rate-Count`: The number of requests made in the current minute.
- `X-Rate-Reset`: The time at which the current rate limit resets.
- `X-Rate-Remaining`: The number of requests remaining.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
