### PR TITLE
feat: add planetary events and joint operations

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -1388,9 +1388,566 @@
 							"body": "{\n    \"data\": [\n        {\n            \"id\": 6,\n            \"type\": 0,\n            \"index\": 50015,\n            \"count\": 2,\n            \"planetId\": 243,\n            \"createdAt\": \"2024-03-14T07:42:25.492Z\",\n            \"updatedAt\": \"2024-03-14T07:42:25.492Z\"\n        }\n    ],\n    \"error\": null,\n    \"pagination\": {\n        \"page\": 1,\n        \"pageSize\": 15,\n        \"pageCount\": 1,\n        \"total\": 1\n    }\n}"
 						}
 					]
+				},
+				{
+					"name": "/api/planets/:id/orders",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/planets/:id/orders",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"planets",
+								":id",
+								"orders"
+							],
+							"query": [
+								{
+									"key": "filters",
+									"value": "",
+									"description": "Filter results based on available fields",
+									"disabled": true
+								},
+								{
+									"key": "sort",
+									"value": "",
+									"description": "Sort results, can be an array or object",
+									"disabled": true
+								},
+								{
+									"key": "select",
+									"value": "",
+									"description": "Only selects provided fields for response",
+									"disabled": true
+								},
+								{
+									"key": "include",
+									"value": "",
+									"description": "Include relations in response",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Limit the number of results",
+									"disabled": true
+								},
+								{
+									"key": "start",
+									"value": "",
+									"description": "Start cursor at specific index",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "170",
+									"description": "The id of the entity to retrieve"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/planets/:id/orders",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"planets",
+										":id",
+										"orders"
+									],
+									"query": [
+										{
+											"key": "select",
+											"value": "",
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": "",
+											"description": "Include relations in response",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "170",
+											"description": "The id of the entity to retrieve"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "1"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "199"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710837102423"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:30:54 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "381"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": [\n        {\n            \"id\": 1,\n            \"index\": 4320,\n            \"planetId\": 170,\n            \"factionId\": 2,\n            \"campaignId\": 6,\n            \"eventType\": \"DEFEND\",\n            \"health\": 506501,\n            \"maxHealth\": 1800000,\n            \"hqNodeIndex\": 2,\n            \"startTime\": \"1970-01-01T00:53:37.040Z\",\n            \"expireTime\": \"1970-01-01T00:55:03.440Z\",\n            \"createdAt\": \"2024-03-19T08:15:43.721Z\",\n            \"updatedAt\": \"2024-03-19T08:15:43.721Z\"\n        }\n    ],\n    \"error\": null,\n    \"pagination\": {\n        \"page\": 1,\n        \"pageSize\": 15,\n        \"pageCount\": 1,\n        \"total\": 1\n    }\n}"
+						}
+					]
 				}
 			],
 			"description": "Celestial bodies inside a sector. As the war for democracy rages on, the planets are the main battlegrounds. Planets carry player counts and have a controlling faction."
+		},
+		{
+			"name": "Orders",
+			"item": [
+				{
+					"name": "/api/orders",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/orders",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"orders"
+							],
+							"query": [
+								{
+									"key": "filters",
+									"value": "",
+									"description": "Filter results based on available fields",
+									"disabled": true
+								},
+								{
+									"key": "sort",
+									"value": null,
+									"description": "Sort results, can be an array or object",
+									"disabled": true
+								},
+								{
+									"key": "select",
+									"value": null,
+									"description": "Only selects provided fields for response",
+									"disabled": true
+								},
+								{
+									"key": "include",
+									"value": null,
+									"description": "Include relations in response",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": null,
+									"description": "Limit the number of results",
+									"disabled": true
+								},
+								{
+									"key": "start",
+									"value": null,
+									"description": "Start cursor at specific index",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/orders",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"orders"
+									],
+									"query": [
+										{
+											"key": "filters",
+											"value": "",
+											"description": "Filter results based on available fields",
+											"disabled": true
+										},
+										{
+											"key": "sort",
+											"value": null,
+											"description": "Sort results, can be an array or object",
+											"disabled": true
+										},
+										{
+											"key": "select",
+											"value": null,
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": null,
+											"description": "Include relations in response",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": null,
+											"description": "Limit the number of results",
+											"disabled": true
+										},
+										{
+											"key": "start",
+											"value": null,
+											"description": "Start cursor at specific index",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "4"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "196"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710836953670"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:29:22 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "381"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": [\n        {\n            \"id\": 1,\n            \"index\": 4320,\n            \"planetId\": 170,\n            \"factionId\": 2,\n            \"campaignId\": 6,\n            \"eventType\": \"DEFEND\",\n            \"health\": 506501,\n            \"maxHealth\": 1800000,\n            \"hqNodeIndex\": 2,\n            \"startTime\": \"1970-01-01T00:53:37.040Z\",\n            \"expireTime\": \"1970-01-01T00:55:03.440Z\",\n            \"createdAt\": \"2024-03-19T08:15:43.721Z\",\n            \"updatedAt\": \"2024-03-19T08:15:43.721Z\"\n        }\n    ],\n    \"error\": null,\n    \"pagination\": {\n        \"page\": 1,\n        \"pageSize\": 15,\n        \"pageCount\": 1,\n        \"total\": 1\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "/api/orders/:id",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/orders/:id",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"orders",
+								":id"
+							],
+							"query": [
+								{
+									"key": "select",
+									"value": "",
+									"description": "Only selects provided fields for response",
+									"disabled": true
+								},
+								{
+									"key": "include",
+									"value": "",
+									"description": "Include relations in response",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "1",
+									"description": "The id of the entity to retrieve"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/orders/:id",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"orders",
+										":id"
+									],
+									"query": [
+										{
+											"key": "select",
+											"value": "",
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": "",
+											"description": "Include relations in response",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "1",
+											"description": "The id of the entity to retrieve"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "1"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "199"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710836953670"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:28:45 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "317"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": {\n        \"id\": 1,\n        \"index\": 4320,\n        \"planetId\": 170,\n        \"factionId\": 2,\n        \"campaignId\": 6,\n        \"eventType\": \"DEFEND\",\n        \"health\": 506501,\n        \"maxHealth\": 1800000,\n        \"hqNodeIndex\": 2,\n        \"startTime\": \"1970-01-01T00:53:37.040Z\",\n        \"expireTime\": \"1970-01-01T00:55:03.440Z\",\n        \"createdAt\": \"2024-03-19T08:15:43.721Z\",\n        \"updatedAt\": \"2024-03-19T08:15:43.721Z\"\n    },\n    \"error\": null\n}"
+						},
+						{
+							"name": "Not Found",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/orders/:id",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"orders",
+										":id"
+									],
+									"query": [
+										{
+											"key": "select",
+											"value": "",
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": "",
+											"description": "Include relations in response",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "1000",
+											"description": "The id of the entity to retrieve"
+										}
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "2"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "198"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710836953670"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:28:59 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "68"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": null,\n    \"error\": {\n        \"details\": [\n            \"Order with id (1000) not found\"\n        ]\n    }\n}"
+						},
+						{
+							"name": "Internal Server Error",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/orders/:id",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"orders",
+										":id"
+									],
+									"query": [
+										{
+											"key": "select",
+											"value": "",
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": "",
+											"description": "Include relations in response",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "hello",
+											"description": "The id of the entity to retrieve"
+										}
+									]
+								}
+							},
+							"status": "Internal Server Error",
+							"code": 500,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "3"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "197"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710836953670"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:29:10 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "70"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": null,\n    \"error\": {\n        \"details\": [\n            \"Invalid value for parameter (id)\"\n        ]\n    }\n}"
+						}
+					]
+				}
+			],
+			"description": "Determine what planets need to be defended or attacked. When a attack/defend order is given, the whole community will try to attack/defend the planet."
 		},
 		{
 			"name": "Attacks",
@@ -2865,6 +3422,147 @@
 							"body": "{\n    \"data\": [\n        {\n            \"id\": 154,\n            \"index\": 153,\n            \"name\": \"Draupnir\",\n            \"ownerId\": 3,\n            \"sectorId\": 7,\n            \"health\": 667332,\n            \"maxHealth\": 1000000,\n            \"players\": 16339,\n            \"disabled\": false,\n            \"regeneration\": 4,\n            \"initialOwnerId\": 1,\n            \"positionX\": -0.745425,\n            \"positionY\": -0.1314594,\n            \"globalEventId\": null,\n            \"createdAt\": \"2024-03-14T07:42:25.120Z\",\n            \"updatedAt\": \"2024-03-14T07:42:25.120Z\"\n        },\n        {\n            \"id\": 241,\n            \"index\": 240,\n            \"name\": \"Troost\",\n            \"ownerId\": 3,\n            \"sectorId\": 7,\n            \"health\": 1000000,\n            \"maxHealth\": 1000000,\n            \"players\": 0,\n            \"disabled\": false,\n            \"regeneration\": 4,\n            \"initialOwnerId\": 1,\n            \"positionX\": -0.9021621,\n            \"positionY\": 0.15547518,\n            \"globalEventId\": null,\n            \"createdAt\": \"2024-03-14T07:42:25.383Z\",\n            \"updatedAt\": \"2024-03-14T07:42:25.383Z\"\n        },\n        {\n            \"id\": 243,\n            \"index\": 242,\n            \"name\": \"Ustotu\",\n            \"ownerId\": 3,\n            \"sectorId\": 7,\n            \"health\": 1000000,\n            \"maxHealth\": 1000000,\n            \"players\": 1876,\n            \"disabled\": false,\n            \"regeneration\": 4,\n            \"initialOwnerId\": 1,\n            \"positionX\": -0.806865,\n            \"positionY\": 0.20750636,\n            \"globalEventId\": null,\n            \"createdAt\": \"2024-03-14T07:42:25.388Z\",\n            \"updatedAt\": \"2024-03-14T07:42:25.388Z\"\n        },\n        {\n            \"id\": 244,\n            \"index\": 243,\n            \"name\": \"Vandalon IV\",\n            \"ownerId\": 3,\n            \"sectorId\": 7,\n            \"health\": 1000000,\n            \"maxHealth\": 1000000,\n            \"players\": 11,\n            \"disabled\": false,\n            \"regeneration\": 4,\n            \"initialOwnerId\": 1,\n            \"positionX\": -0.840825,\n            \"positionY\": 0.06103413,\n            \"globalEventId\": null,\n            \"createdAt\": \"2024-03-14T07:42:25.390Z\",\n            \"updatedAt\": \"2024-03-14T07:42:25.390Z\"\n        }\n    ],\n    \"error\": null,\n    \"pagination\": {\n        \"page\": 1,\n        \"pageSize\": 15,\n        \"pageCount\": 1,\n        \"total\": 4\n    }\n}"
 						}
 					]
+				},
+				{
+					"name": "/api/factions/:id/orders",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/factions/:id/orders",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"factions",
+								":id",
+								"orders"
+							],
+							"query": [
+								{
+									"key": "filters",
+									"value": "",
+									"description": "Filter results based on available fields",
+									"disabled": true
+								},
+								{
+									"key": "sort",
+									"value": "",
+									"description": "Sort results, can be an array or object",
+									"disabled": true
+								},
+								{
+									"key": "select",
+									"value": "",
+									"description": "Only selects provided fields for response",
+									"disabled": true
+								},
+								{
+									"key": "include",
+									"value": "",
+									"description": "Include relations in response",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Limit the number of results",
+									"disabled": true
+								},
+								{
+									"key": "start",
+									"value": "",
+									"description": "Start cursor at specific index",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "2",
+									"description": "The id of the entity to retrieve"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{api_url}}/api/factions/:id/orders",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"api",
+										"factions",
+										":id",
+										"orders"
+									],
+									"query": [
+										{
+											"key": "select",
+											"value": "",
+											"description": "Only selects provided fields for response",
+											"disabled": true
+										},
+										{
+											"key": "include",
+											"value": "",
+											"description": "Include relations in response",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "2",
+											"description": "The id of the entity to retrieve"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "x-rate-count",
+									"value": "2"
+								},
+								{
+									"key": "x-rate-limit",
+									"value": "200"
+								},
+								{
+									"key": "x-rate-remaining",
+									"value": "198"
+								},
+								{
+									"key": "x-rate-reset",
+									"value": "1710837275319"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 19 Mar 2024 08:33:57 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "381"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": [\n        {\n            \"id\": 1,\n            \"index\": 4320,\n            \"planetId\": 170,\n            \"factionId\": 2,\n            \"campaignId\": 6,\n            \"eventType\": \"DEFEND\",\n            \"health\": 506501,\n            \"maxHealth\": 1800000,\n            \"hqNodeIndex\": 2,\n            \"startTime\": \"1970-01-01T00:53:37.040Z\",\n            \"expireTime\": \"1970-01-01T00:55:03.440Z\",\n            \"createdAt\": \"2024-03-19T08:15:43.721Z\",\n            \"updatedAt\": \"2024-03-19T08:15:43.721Z\"\n        }\n    ],\n    \"error\": null,\n    \"pagination\": {\n        \"page\": 1,\n        \"pageSize\": 15,\n        \"pageCount\": 1,\n        \"total\": 1\n    }\n}"
+						}
+					]
 				}
 			],
 			"description": "Factions are divided in three groups: Terminids, Humans and Automatons. Humans are the only faction that can be controlled by players. The other two are controlled by the game as Non-Player Characters (NPCs)."
@@ -3276,7 +3974,7 @@
 		},
 		{
 			"key": "api_url",
-			"value": "http://localhost:3000",
+			"value": "https://api-helldivers-companion.koyeb.app",
 			"type": "string"
 		}
 	]

--- a/prisma/migrations/20240319081538_orders/migration.sql
+++ b/prisma/migrations/20240319081538_orders/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "Order" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" INTEGER NOT NULL,
+    "planetId" INTEGER,
+    "factionId" INTEGER,
+    "campaignId" INTEGER,
+    "eventType" TEXT NOT NULL,
+    "health" INTEGER NOT NULL,
+    "maxHealth" INTEGER NOT NULL,
+    "hqNodeIndex" INTEGER,
+    "startTime" DATETIME NOT NULL,
+    "expireTime" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Order_planetId_fkey" FOREIGN KEY ("planetId") REFERENCES "Planet" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Order_factionId_fkey" FOREIGN KEY ("factionId") REFERENCES "Faction" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Order_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Order_index_key" ON "Order"("index");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Faction {
   id             Int           @id @default(autoincrement())
   index          Int           @unique
   name           String
+  orders         Order[]       @relation("Order")
   planets        Planet[]      @relation(name: "owner")
   initialPlanets Planet[]      @relation(name: "initialOwner")
   globalEvents   GlobalEvent[]
@@ -59,6 +60,7 @@ model Planet {
   positionY      Float
   globalEvent    GlobalEvent? @relation("GlobalEvent", fields: [globalEventId], references: [id])
   globalEventId  Int?
+  orders         Order[]      @relation("Order")
   campaign       Campaign[]   @relation("Campaign")
   homeWorld      HomeWorld[]  @relation("HomeWorld")
   attacking      Attack[]     @relation("Attack")
@@ -84,6 +86,7 @@ model Campaign {
   type      Int
   index     Int      @unique
   count     Int
+  order     Order[]  @relation("Order")
   planet    Planet   @relation("Campaign", fields: [planetId], references: [id])
   planetId  Int
   createdAt DateTime @default(now())
@@ -98,6 +101,25 @@ model HomeWorld {
   planetId  Int
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Order {
+  id          Int       @id @default(autoincrement())
+  index       Int       @unique
+  planet      Planet?   @relation("Order", fields: [planetId], references: [id])
+  planetId    Int?
+  faction     Faction?  @relation("Order", fields: [factionId], references: [id])
+  factionId   Int?
+  campaign    Campaign? @relation("Order", fields: [campaignId], references: [id])
+  campaignId  Int?
+  eventType   String
+  health      Int
+  maxHealth   Int
+  hqNodeIndex Int?
+  startTime   DateTime
+  expireTime  DateTime
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 }
 
 model Attack {

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -1,0 +1,72 @@
+import type { Context } from "hono";
+import { PrismaClient } from "@prisma/client";
+
+import witCache from "utils/cache";
+import parseIntParam from "utils/params";
+import parseQueryParams from "utils/query";
+
+const prisma = new PrismaClient();
+
+export const getOrderById = await witCache(async (ctx: Context) => {
+  try {
+    const id = parseIntParam(ctx, "id");
+    const query = await parseQueryParams(ctx);
+
+    delete query.orderBy;
+    delete query.where;
+    delete query.orderBy;
+    delete (query as any).skip;
+    delete (query as any).take;
+
+    const order = await prisma.order.findUnique({
+      ...(query as any),
+      where: { id },
+    });
+
+    if (!order) {
+      ctx.status(404);
+      return ctx.json({
+        data: null,
+        error: { details: [`Order with id (${id}) not found`] },
+      });
+    }
+
+    return ctx.json({ data: order, error: null });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});
+
+export const getAllOrders = await witCache(async (ctx: Context) => {
+  try {
+    const query = await parseQueryParams(ctx);
+
+    const [count, orders] = await Promise.all([
+      prisma.order.count({ where: query.where }),
+      prisma.order.findMany(query),
+    ]);
+
+    return ctx.json({
+      data: orders,
+      error: null,
+      pagination: {
+        page: query.skip / query.take + 1,
+        pageSize: query.take,
+        pageCount: Math.ceil((count as number) / query.take),
+        total: count,
+      },
+    });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import cache from "middleware/cache";
 import rateLimit from "middleware/rate-limit";
 
 import wars from "routes/war";
+import orders from "routes/orders";
 import events from "routes/events";
 import planets from "routes/planets";
 import sectors from "routes/sectors";
@@ -18,7 +19,7 @@ app.use(rateLimit);
 app.use(cache);
 
 // routes for the api
-const routes = [planets, sectors, wars, factions, attacks, events];
+const routes = [planets, sectors, wars, factions, attacks, events, orders];
 for (const route of routes) await route(app);
 
 export default app;

--- a/src/routes/factions.ts
+++ b/src/routes/factions.ts
@@ -5,6 +5,7 @@ import * as Factions from "controllers/factions";
 export default async function factions(app: Hono) {
   app.get("/factions", Factions.getAllFactions);
   app.get("/factions/:id", Factions.getFactionById);
+  app.get("/factions/:id/orders", Factions.getFactionOrders);
   app.get("/factions/:id/origins", Factions.getFactionOrigin);
   app.get("/factions/:id/planets", Factions.getFactionPlanets);
   app.get("/factions/:id/pushbacks", Factions.getFactionPushbacks);

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,8 @@
+import type { Hono } from "hono";
+
+import * as Orders from "controllers/orders";
+
+export default async function events(app: Hono) {
+  app.get("/orders", Orders.getAllOrders);
+  app.get("/orders/:id", Orders.getOrderById);
+}

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -2,7 +2,7 @@ import type { Hono } from "hono";
 
 import * as Orders from "controllers/orders";
 
-export default async function events(app: Hono) {
+export default async function orders(app: Hono) {
   app.get("/orders", Orders.getAllOrders);
   app.get("/orders/:id", Orders.getOrderById);
 }

--- a/src/routes/planets.ts
+++ b/src/routes/planets.ts
@@ -5,6 +5,7 @@ import * as Planets from "controllers/planets";
 export default async function planets(app: Hono) {
   app.get("/planets", Planets.getAllPlanets);
   app.get("/planets/:id", Planets.getPlanetById);
+  app.get("/planets/:id/orders", Planets.getPlanetOrders);
   app.get("/planets/:id/owners", Planets.getPlanetOwners);
   app.get("/planets/:id/attacks", Planets.getPlanetAttacks);
   app.get("/planets/:id/campaigns", Planets.getPlanetCampaigns);

--- a/src/types/source.ts
+++ b/src/types/source.ts
@@ -56,6 +56,25 @@ export interface HomeWorld {
   planetIndices: number[];
 }
 
+export interface JointOperation {
+  id: number;
+  planetIndex: number;
+  hqNodeIndex: number;
+}
+
+export interface PlanetEvent {
+  id: number;
+  planetIndex: number;
+  eventType: number;
+  race: number;
+  health: number;
+  maxHealth: number;
+  startTime: number;
+  expireTime: number;
+  campaignId: number;
+  jointOperationIds: number[];
+}
+
 export interface WarStatus {
   warId: number;
   time: number;
@@ -65,8 +84,8 @@ export interface WarStatus {
   planetAttacks: PlanetAttack[];
   campaigns: Campaign[];
   communityTargets: never[];
-  jointOperations: never[];
-  planetEvents: never[];
+  jointOperations: JointOperation[];
+  planetEvents: PlanetEvent[];
   planetActiveEffects: never[];
   activeElectionPolicyEffects: never[];
   globalEvents: GlobalEvent[];


### PR DESCRIPTION
## Description

This PR introduces some new endpoints related to the planetary events _(attack/defend-orders)_. Following endpoints have been added:

- `/api/orders`: List all current attack/defend orders
- `/api/orders/:id`: Get a specific  attack/defend order by id
- `/api/planets/:id/orders`: List all current attack/defend orders for a planet
- `/api/factions/:id/orders`: List all current attack/defend orders for a faction

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
