### PR TITLE
chore(tests): add testing suite for routes and methods

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,4 +18,6 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
+      - run: bun prisma generate
+      - run: bunx prisma migrate dev
       - run: bun test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - run: bun install
+      - run: PRISMA_CLI_BINARY_TARGETS=debian-openssl-3.0.x bun install
       - run: bunx prisma generate
       - run: bunx prisma migrate dev
       - run: bun generate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,14 @@
 name: Tests
 
 env:
+  # prisma setip
+  PRISMA_CLI_BINARY_TARGETS: "debian-openssl-3.0.x"
   DATABASE_URL: "file:./database/data.db"
+  # api setup
   WAR_ID: "801"
   RATE_LIMIT: "200"
   API_URL: "https://api.live.prod.thehelldiversgame.com/api"
+  # stratagem setup
   STRATAGEM_IMAGE_URL: "https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,7 @@
 name: Tests
 
 env:
-  # Primsa configuration
   DATABASE_URL: "file:./database/data.db"
-  # API configuration
   WAR_ID: "801"
   RATE_LIMIT: "200"
   API_URL: "https://api.live.prod.thehelldiversgame.com/api"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,14 @@
 name: Tests
 
+env:
+  # Primsa configuration
+  DATABASE_URL: "file:./database/data.db"
+  # API configuration
+  WAR_ID: "801"
+  RATE_LIMIT: "200"
+  API_URL: "https://api.live.prod.thehelldiversgame.com/api"
+  STRATAGEM_IMAGE_URL: "https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"
+
 on:
   pull_request:
     branches:
@@ -20,4 +29,5 @@ jobs:
       - run: bun install
       - run: bunx prisma generate
       - run: bunx prisma migrate dev
+      - run: bun generate
       - run: bun test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
-      - run: bun prisma generate
+      - run: bunx prisma generate
       - run: bunx prisma migrate dev
       - run: bun test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 env:
   # prisma setip
-  PRISMA_CLI_BINARY_TARGETS: "debian-openssl-3.0.x"
   DATABASE_URL: "file:./database/data.db"
   # api setup
   WAR_ID: "801"
@@ -28,8 +27,8 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - run: PRISMA_CLI_BINARY_TARGETS=debian-openssl-3.0.x bun install
+      - run: bun install
       - run: bunx prisma generate
-      - run: bunx prisma migrate dev
+      - run: bunx prisma migrate deploy
       - run: bun generate
       - run: bun test

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ RUN bunx prisma generate
 # fetch the initial data
 RUN bun run generate
 
+# test the app
+RUN bun test
+
 # build the app
 RUN bun run output
 

--- a/__tests__/routes/attacks.test.ts
+++ b/__tests__/routes/attacks.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import { describe, expect, it } from "bun:test";
 import type { Planet, Attack } from "@prisma/client";
 

--- a/__tests__/routes/attacks.test.ts
+++ b/__tests__/routes/attacks.test.ts
@@ -1,0 +1,48 @@
+import app from "index";
+import { describe, expect, it } from "bun:test";
+import type { Planet, Attack } from "@prisma/client";
+
+describe("Attack endpoints work as expected", () => {
+  it("GET /attacks", async () => {
+    const response = await app.request("/api/attacks");
+    const json: { data: Attack[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /attacks/:id", async () => {
+    try {
+      const response = await app.request("/api/attacks/16");
+      const json: { data: Attack; error: object | null } =
+        (await response.json()) as any;
+      expect(response.status).toBe(200);
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("id");
+    } catch {
+      // this is ok, there is not always an attack with id 16
+      // because they are more dynamic than other entities
+    }
+  });
+
+  it("GET /attacks/:id/planets", async () => {
+    try {
+      const response = await app.request("/api/attacks/16/planets");
+      const json: {
+        data: { source: Planet; target: Planet };
+        error: object | null;
+      } = (await response.json()) as any;
+      expect(response.status).toBe(200);
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("source");
+      expect(json.data).toHaveProperty("target");
+      expect(json.data.source).toHaveProperty("id");
+      expect(json.data.target).toHaveProperty("id");
+    } catch {
+      // this is ok, there is not always an attack with id 16
+      // because they are more dynamic than other entities
+      expect(true).toBe(true);
+    }
+  });
+});

--- a/__tests__/routes/events.test.ts
+++ b/__tests__/routes/events.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import { describe, expect, it } from "bun:test";
 import type { GlobalEvent } from "@prisma/client";
 

--- a/__tests__/routes/events.test.ts
+++ b/__tests__/routes/events.test.ts
@@ -1,0 +1,28 @@
+import app from "index";
+import { describe, expect, it } from "bun:test";
+import type { GlobalEvent } from "@prisma/client";
+
+describe("Event endpoints work as expected", () => {
+  it("GET /events", async () => {
+    const response = await app.request("/api/events");
+    const json: { data: GlobalEvent[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /events/:id", async () => {
+    try {
+      const response = await app.request("/api/events/1");
+      const json: { data: GlobalEvent; error: object | null } =
+        (await response.json()) as any;
+      expect(response.status).toBe(200);
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("id");
+    } catch {
+      // this is ok, there is not always an event with id 1
+      // because they are more dynamic than other entities
+    }
+  });
+});

--- a/__tests__/routes/factions.test.ts
+++ b/__tests__/routes/factions.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import { describe, expect, it } from "bun:test";
 import type { Faction, Order, Planet } from "@prisma/client";
 

--- a/__tests__/routes/factions.test.ts
+++ b/__tests__/routes/factions.test.ts
@@ -1,0 +1,59 @@
+import app from "index";
+import { describe, expect, it } from "bun:test";
+import type { Faction, Order, Planet } from "@prisma/client";
+
+describe("Faction endpoints work as expected", () => {
+  it("GET /factions", async () => {
+    const response = await app.request("/api/factions");
+    const json: { data: Faction[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /factions/:id", async () => {
+    const response = await app.request("/api/factions/1");
+    const json: { data: Faction; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+
+  it("GET /factions/:id/orders", async () => {
+    const response = await app.request("/api/factions/1/orders");
+    const json: { data: Order[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /factions/:id/origins", async () => {
+    const response = await app.request("/api/factions/1/origins");
+    const json: { data: Planet; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+
+  it("GET /factions/:id/planets", async () => {
+    const response = await app.request("/api/factions/1/planets");
+    const json: { data: Planet[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /factions/:id/pushbacks", async () => {
+    const response = await app.request("/api/factions/1/pushbacks");
+    const json: { data: Planet[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+});

--- a/__tests__/routes/orders.test.ts
+++ b/__tests__/routes/orders.test.ts
@@ -1,0 +1,30 @@
+import app from "index";
+import type { Order } from "@prisma/client";
+import { describe, expect, it } from "bun:test";
+
+let res = null;
+
+describe("Order endpoints work as expected", () => {
+  it("GET /orders", async () => {
+    const response = await app.request("/api/orders");
+    const json: { data: Order[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /orders/:id", async () => {
+    try {
+      const response = await app.request("/api/orders/1");
+      const json: { data: Order; error: object | null } =
+        (await response.json()) as any;
+      expect(response.status).toBe(200);
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("id");
+    } catch {
+      // this is ok, there is not always an order with id 16
+      // because they are more dynamic than other entities
+    }
+  });
+});

--- a/__tests__/routes/orders.test.ts
+++ b/__tests__/routes/orders.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import type { Order } from "@prisma/client";
 import { describe, expect, it } from "bun:test";
 

--- a/__tests__/routes/planets.test.ts
+++ b/__tests__/routes/planets.test.ts
@@ -1,0 +1,56 @@
+import app from "index";
+import type { Planet } from "@prisma/client";
+import { describe, expect, it } from "bun:test";
+
+describe("Planet endpoints work as expected", () => {
+  it("GET /planets", async () => {
+    const response = await app.request("/api/planets");
+    const json: { data: Planet[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /planets/:id", async () => {
+    const response = await app.request("/api/planets/1");
+    const json: { data: Planet; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+
+  it("GET /planets/:id/owners", async () => {
+    const response = await app.request("/api/planets/16/owners");
+    const json: { data: Record<any, any>; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("owner");
+    expect(json.data).toHaveProperty("initialOwner");
+    expect(json.data.owner).toHaveProperty("id");
+    expect(json.data.initialOwner).toHaveProperty("id");
+  });
+
+  it("GET /planets/:id/attacks", async () => {
+    const response = await app.request("/api/planets/1/attacks");
+    const json: { data: Record<any, any>; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("attacking");
+    expect(json.data).toHaveProperty("defending");
+    expect(json.data.defending).toBeInstanceOf(Array);
+    expect(json.data.attacking).toBeInstanceOf(Array);
+  });
+
+  it("GET /planets/:id/campaigns", async () => {
+    const response = await app.request("/api/planets/1/campaigns");
+    const json: { data: Planet[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+});

--- a/__tests__/routes/planets.test.ts
+++ b/__tests__/routes/planets.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import type { Planet } from "@prisma/client";
 import { describe, expect, it } from "bun:test";
 

--- a/__tests__/routes/sectors.test.ts
+++ b/__tests__/routes/sectors.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import { describe, expect, it } from "bun:test";
 import type { Planet, Sector } from "@prisma/client";
 

--- a/__tests__/routes/sectors.test.ts
+++ b/__tests__/routes/sectors.test.ts
@@ -1,0 +1,32 @@
+import app from "index";
+import { describe, expect, it } from "bun:test";
+import type { Planet, Sector } from "@prisma/client";
+
+describe("Sector endpoints work as expected", () => {
+  it("GET /sectors", async () => {
+    const response = await app.request("/api/sectors");
+    const json: { data: Sector[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /sectors/:id", async () => {
+    const response = await app.request("/api/sectors/1");
+    const json: { data: Sector; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+
+  it("GET /sectors/:id/planets", async () => {
+    const response = await app.request("/api/sectors/1/planets");
+    const json: { data: Planet[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+});

--- a/__tests__/routes/stratagems.test.ts
+++ b/__tests__/routes/stratagems.test.ts
@@ -1,0 +1,23 @@
+import app from "index";
+import { describe, expect, it } from "bun:test";
+import type { Stratagem } from "@prisma/client";
+
+describe("Stratagem endpoints work as expected", () => {
+  it("GET /stratagems", async () => {
+    const response = await app.request("/api/stratagems");
+    const json: { data: Stratagem[]; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toBeInstanceOf(Array);
+  });
+
+  it("GET /stratagems/:id", async () => {
+    const response = await app.request("/api/stratagems/1");
+    const json: { data: Stratagem; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+});

--- a/__tests__/routes/stratagems.test.ts
+++ b/__tests__/routes/stratagems.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import { describe, expect, it } from "bun:test";
 import type { Stratagem } from "@prisma/client";
 

--- a/__tests__/routes/war.test.ts
+++ b/__tests__/routes/war.test.ts
@@ -1,4 +1,4 @@
-import app from "index";
+import app from "../../src";
 import type { War } from "@prisma/client";
 import { describe, expect, it } from "bun:test";
 

--- a/__tests__/routes/war.test.ts
+++ b/__tests__/routes/war.test.ts
@@ -1,0 +1,14 @@
+import app from "index";
+import type { War } from "@prisma/client";
+import { describe, expect, it } from "bun:test";
+
+describe("War endpoint work as expected", () => {
+  it("GET /war", async () => {
+    const response = await app.request("/api/war");
+    const json: { data: War; error: object | null } =
+      (await response.json()) as any;
+    expect(response.status).toBe(200);
+    expect(json).toHaveProperty("data");
+    expect(json.data).toHaveProperty("id");
+  });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-3.0.x"]
+  provider = "prisma-client-js"
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Description

This PR adds a testing suite and action for the routes and methods of the API. We use the standard test framework provided by Bun. The tests are written in TypeScript and are located in the `__tests__` directory.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refractor (non-breaking change which cleans up code)

## How Has This Been Tested?

Added following tests for the current routes

- attacks.test.ts
- events.test.ts
- factions.test.ts
- orders.test.ts
- planets.test.ts
- sectors.test.ts
- stratagems.test.ts
- war.test.ts

### Test Configuration

- Bun version: 1.0.25

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
