### PR TITLE
refractor: decrease cron interval duration

### DIFF
--- a/src/jobs/refresh.ts
+++ b/src/jobs/refresh.ts
@@ -4,7 +4,7 @@ import Cache from "memory-cache";
 import { refreshAndStoreSourceData } from "utils/refresh";
 
 new CronJob(
-  "0 */30 * * * *",
+  "0 */1 * * * *",
   async () => {
     const startDate = Date.now();
     console.log("Refreshing source data");

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -12,7 +12,7 @@ export default async function witCache(cb: RouteController) {
     Cache.put(
       key,
       JSON.stringify({ status: response.status, data }),
-      30 * 60 * 1000,
+      (1 * 50 * 1000) / 1.5,
     );
 
     ctx.status(response.status as any);


### PR DESCRIPTION
## Description

This PR modifies the synchronization time for the API. After testing the stability of the API for a couple of weeks now, we have decided to decrease the interval from 30 minutes to just 1 minute.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refractor (non-breaking change which cleans up code)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
