### PR TITLE
fix: provide fallback value for `message` property

### DIFF
--- a/src/utils/refresh.ts
+++ b/src/utils/refresh.ts
@@ -67,7 +67,7 @@ export async function refreshAndStoreSourceData() {
       data: {
         index: article.id,
         type: article.type,
-        message: article.message,
+        message: article.message ?? "",
         tagIds: article.tagIds.join(","),
         publishedAt: new Date(article.published * 1000),
       },


### PR DESCRIPTION
## Description

This PR ensures the `message` property of the `news` data type is always a string. Observations show that the API may crash when the value is undefined.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
