### PR TITLE
fix: ensure cache is served until poll is complete

### DIFF
--- a/src/jobs/refresh.ts
+++ b/src/jobs/refresh.ts
@@ -10,8 +10,8 @@ new CronJob(
     try {
       console.log("Refreshing source data");
 
-      RequestCache.flushAll();
       await refreshAndStoreSourceData();
+      RequestCache.flushAll();
 
       const endDate = Date.now();
       console.log(`Source data refreshed in ${endDate - startDate}ms`);

--- a/src/utils/request-cache.ts
+++ b/src/utils/request-cache.ts
@@ -10,7 +10,7 @@ export default async function witCache(cb: RouteController) {
     const response = await cb(ctx);
 
     const data = await response.json();
-    RequestCache.set(key, { status: response.status, data }, 50);
+    RequestCache.set(key, { status: response.status, data }, 120);
 
     ctx.status(response.status as any);
     return ctx.json(data);


### PR DESCRIPTION
## Description

This PR ensures the request cache is served while the data is updated. When the data is updated and the promise is resolved, the cache will reset.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
