### PR TITLE
fix: ensure newest report data is available and properly sorted

### DIFF
--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -220,7 +220,7 @@ export async function transformAndStoreSourceData() {
   }
 
   // generate news data
-  for (const article of warNews) {
+  for (const article of warNews.sort((a, b) => a.id - b.id)) {
     await prisma.news.create({
       data: {
         index: article.id,

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -139,7 +139,7 @@ export async function fetchSourceData() {
         "Accept-Language": "en-US",
       },
     }),
-    fetch(`${API_URL}/NewsFeed/${warId}`, {
+    fetch(`${API_URL}/NewsFeed/${warId}?maxEntries=1024`, {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",

--- a/src/utils/refresh.ts
+++ b/src/utils/refresh.ts
@@ -62,7 +62,7 @@ export async function refreshAndStoreSourceData() {
 
   // generate news data
   await prisma.news.deleteMany();
-  for (const article of warNews) {
+  for (const article of warNews.sort((a, b) => a.id - b.id)) {
     await prisma.news.create({
       data: {
         index: article.id,


### PR DESCRIPTION
## Description

This PR fixes an issue where the last report would be "The TCS has been fully activated on half of the Barrier Planets." as last entry even if that is substantially out of date.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
