### PR TITLE
feat: add liberation fields

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ env:
   DATABASE_URL: "file:./database/data.db"
   # api setup
   RATE_LIMIT: "200"
+  HISTORY_API_URL: "https://helldivers-b.omnedia.com/api"
   API_URL: "https://api.live.prod.thehelldiversgame.com/api"
   # stratagem setup
   STRATAGEM_IMAGE_URL: "https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/app
 # Set environment variables
 ENV RATE_LIMIT="200"
 ENV DATABASE_URL="file:./database/data.db"
+ENV HISTORY_API_URL="https://helldivers-b.omnedia.com/api"
 ENV API_URL="https://api.live.prod.thehelldiversgame.com/api"
 ENV STRATAGEM_IMAGE_URL="https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"
 

--- a/prisma/migrations/20240405123412_liberation/migration.sql
+++ b/prisma/migrations/20240405123412_liberation/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - Added the required column `liberation` to the `Planet` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `liberationRate` to the `Planet` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `liberationState` to the `Planet` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Planet" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" BIGINT NOT NULL,
+    "name" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "sectorId" INTEGER NOT NULL,
+    "health" INTEGER NOT NULL,
+    "maxHealth" INTEGER NOT NULL,
+    "players" INTEGER NOT NULL,
+    "disabled" BOOLEAN NOT NULL,
+    "regeneration" INTEGER NOT NULL,
+    "liberation" REAL NOT NULL,
+    "liberationRate" REAL NOT NULL,
+    "liberationState" TEXT NOT NULL,
+    "initialOwnerId" INTEGER NOT NULL,
+    "positionX" REAL NOT NULL,
+    "positionY" REAL NOT NULL,
+    "globalEventId" INTEGER,
+    "statisticId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Planet_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_sectorId_fkey" FOREIGN KEY ("sectorId") REFERENCES "Sector" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_initialOwnerId_fkey" FOREIGN KEY ("initialOwnerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_globalEventId_fkey" FOREIGN KEY ("globalEventId") REFERENCES "GlobalEvent" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Planet_statisticId_fkey" FOREIGN KEY ("statisticId") REFERENCES "Stats" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Planet" ("createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt") SELECT "createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt" FROM "Planet";
+DROP TABLE "Planet";
+ALTER TABLE "new_Planet" RENAME TO "Planet";
+CREATE UNIQUE INDEX "Planet_index_key" ON "Planet"("index");
+CREATE UNIQUE INDEX "Planet_statisticId_key" ON "Planet"("statisticId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,33 +44,36 @@ model Faction {
 }
 
 model Planet {
-  id             Int          @id @default(autoincrement())
-  index          BigInt       @unique
-  name           String
-  owner          Faction      @relation(name: "owner", fields: [ownerId], references: [id])
-  ownerId        Int
-  sector         Sector       @relation(fields: [sectorId], references: [id])
-  sectorId       Int
-  health         Int
-  maxHealth      Int
-  players        Int
-  disabled       Boolean
-  regeneration   Int
-  initialOwner   Faction      @relation(name: "initialOwner", fields: [initialOwnerId], references: [id])
-  initialOwnerId Int
-  positionX      Float
-  positionY      Float
-  globalEvent    GlobalEvent? @relation("GlobalEvent", fields: [globalEventId], references: [id])
-  globalEventId  Int?
-  orders         Order[]      @relation("Order")
-  campaign       Campaign[]   @relation("Campaign")
-  homeWorld      HomeWorld[]  @relation("HomeWorld")
-  attacking      Attack[]     @relation("Attack")
-  defending      Attack[]     @relation("Defend")
-  statistic      Stats?       @relation(fields: [statisticId], references: [id])
-  statisticId    Int?         @unique
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  id              Int          @id @default(autoincrement())
+  index           BigInt       @unique
+  name            String
+  owner           Faction      @relation(name: "owner", fields: [ownerId], references: [id])
+  ownerId         Int
+  sector          Sector       @relation(fields: [sectorId], references: [id])
+  sectorId        Int
+  health          Int
+  maxHealth       Int
+  players         Int
+  disabled        Boolean
+  regeneration    Int
+  liberation      Float
+  liberationRate  Float
+  liberationState String
+  initialOwner    Faction      @relation(name: "initialOwner", fields: [initialOwnerId], references: [id])
+  initialOwnerId  Int
+  positionX       Float
+  positionY       Float
+  globalEvent     GlobalEvent? @relation("GlobalEvent", fields: [globalEventId], references: [id])
+  globalEventId   Int?
+  orders          Order[]      @relation("Order")
+  campaign        Campaign[]   @relation("Campaign")
+  homeWorld       HomeWorld[]  @relation("HomeWorld")
+  attacking       Attack[]     @relation("Attack")
+  defending       Attack[]     @relation("Defend")
+  statistic       Stats?       @relation(fields: [statisticId], references: [id])
+  statisticId     Int?         @unique
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
 }
 
 model GlobalEvent {

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,8 @@
+export interface HistoryEntry {
+  planetIndex: number;
+  maxHealth: number;
+  liberation: number;
+  currentHealth: number;
+  previousLiberation: number;
+  liberationChange: number;
+}

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -100,6 +100,7 @@ export async function prepareForSourceData() {
  */
 export async function fetchSourceData() {
   const API_URL = process.env.API_URL!;
+  const HISTORY_API_URL = process.env.HISTORY_API_URL!;
 
   const response = await fetch(`${API_URL}/WarSeason/current/WarID`, {
     headers: {
@@ -154,7 +155,7 @@ export async function fetchSourceData() {
         "Accept-Language": "en-US",
       },
     }),
-    fetch(`${process.env.HISTORY_API_URL}/current-planets-progress`, {
+    fetch(`${HISTORY_API_URL}/current-planets-progress`, {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",


### PR DESCRIPTION
## Description

This PR adds new fields to the `Planet` model that contain information about the current liberation progress for each planet. Following fields were added in particular:

- `liberation`: The percentage of the planet currently liberated.
- `liberationRate`: The liberation rate in percent per hour.
- `liberationState`:  One of the following:  `WINNING`, `DRAW`,  `LOSING`, `N/A`

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
