### PR TITLE
fix: address deployment memory issues

### DIFF
--- a/src/controllers/assignments.ts
+++ b/src/controllers/assignments.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getAssignmentById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getAssignmentById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const assignment = await prisma.assignment.findUnique({
+    const assignment = await db.assignment.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllAssignments = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, assignments] = await Promise.all([
-      prisma.assignment.count({ where: query.where }),
-      prisma.assignment.findMany(query),
+      db.assignment.count({ where: query.where }),
+      db.assignment.findMany(query),
     ]);
 
     return ctx.json({
@@ -82,7 +80,7 @@ export const getAssignmentReward = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const reward = await prisma.reward.findFirst({
+    const reward = await db.reward.findFirst({
       where: { assignment: { id } },
     });
 

--- a/src/controllers/attacks.ts
+++ b/src/controllers/attacks.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getAttackById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getAttackById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const attack = await prisma.attack.findUnique({
+    const attack = await db.attack.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllAttacks = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, attacks] = await Promise.all([
-      prisma.attack.count({ where: query.where }),
-      prisma.attack.findMany(query),
+      db.attack.count({ where: query.where }),
+      db.attack.findMany(query),
     ]);
 
     return ctx.json({
@@ -83,10 +81,10 @@ export const getPlanetsByAttack = await witCache(async (ctx: Context) => {
     delete (query as any).take;
 
     const [target, source] = await Promise.all([
-      prisma.planet.findFirst({
+      db.planet.findFirst({
         where: { attacking: { some: { id } } },
       }),
-      prisma.planet.findFirst({
+      db.planet.findFirst({
         where: { defending: { some: { id } } },
       }),
     ]);

--- a/src/controllers/events.ts
+++ b/src/controllers/events.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getEventById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getEventById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const event = await prisma.globalEvent.findUnique({
+    const event = await db.globalEvent.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllEvents = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, events] = await Promise.all([
-      prisma.globalEvent.count({ where: query.where }),
-      prisma.globalEvent.findMany(query),
+      db.globalEvent.count({ where: query.where }),
+      db.globalEvent.findMany(query),
     ]);
 
     return ctx.json({

--- a/src/controllers/factions.ts
+++ b/src/controllers/factions.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getFactionById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getFactionById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const faction = await prisma.faction.findUnique({
+    const faction = await db.faction.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllFactions = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, factions] = await Promise.all([
-      prisma.faction.count({ where: query.where }),
-      prisma.faction.findMany(query),
+      db.faction.count({ where: query.where }),
+      db.faction.findMany(query),
     ]);
 
     return ctx.json({
@@ -77,10 +75,10 @@ export const getFactionPlanets = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, planets] = await Promise.all([
-      prisma.planet.count({
+      db.planet.count({
         where: { ...(query.where ?? {}), ownerId: id },
       }),
-      prisma.planet.findMany({
+      db.planet.findMany({
         ...query,
         where: { ...(query.where ?? {}), ownerId: id },
       }),
@@ -112,14 +110,14 @@ export const getFactionPushbacks = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, planets] = await Promise.all([
-      prisma.planet.count({
+      db.planet.count({
         where: {
           ...(query.where ?? {}),
           ownerId: { not: id },
           initialOwnerId: id,
         },
       }),
-      prisma.planet.findMany({
+      db.planet.findMany({
         ...query,
         where: {
           ...(query.where ?? {}),
@@ -160,7 +158,7 @@ export const getFactionOrigin = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const planet = await prisma.planet.findFirst({
+    const planet = await db.planet.findFirst({
       ...(query as any),
       where: { homeWorld: { some: { factionId: id } } },
     });
@@ -192,10 +190,10 @@ export const getFactionOrders = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, orders] = await Promise.all([
-      prisma.order.count({
+      db.order.count({
         where: { ...(query.where ?? {}), factionId: id },
       }),
-      prisma.order.findMany({
+      db.order.findMany({
         ...query,
         where: { ...(query.where ?? {}), factionId: id },
       }),

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getOrderById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getOrderById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const order = await prisma.order.findUnique({
+    const order = await db.order.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllOrders = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, orders] = await Promise.all([
-      prisma.order.count({ where: query.where }),
-      prisma.order.findMany(query),
+      db.order.count({ where: query.where }),
+      db.order.findMany(query),
     ]);
 
     return ctx.json({

--- a/src/controllers/planets.ts
+++ b/src/controllers/planets.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getPlanetById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getPlanetById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const planet = await prisma.planet.findUnique({
+    const planet = await db.planet.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllPlanets = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, planets] = await Promise.all([
-      prisma.planet.count({ where: query.where }),
-      prisma.planet.findMany(query),
+      db.planet.count({ where: query.where }),
+      db.planet.findMany(query),
     ]);
 
     return ctx.json({
@@ -77,12 +75,12 @@ export const getPlanetAttacks = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, attacks] = await Promise.all([
-      prisma.attack.count({
+      db.attack.count({
         where: {
           OR: [{ source: { id } }, { target: { id } }],
         },
       }),
-      prisma.attack.findMany({
+      db.attack.findMany({
         ...(query ?? {}),
         where: {
           ...(query.where as any),
@@ -130,10 +128,10 @@ export const getPlanetOwners = await witCache(async (ctx: Context) => {
     delete (query as any).take;
 
     const [owner, initialOwner] = await Promise.all([
-      prisma.faction.findFirst({
+      db.faction.findFirst({
         where: { planets: { some: { id } } },
       }),
-      prisma.faction.findFirst({
+      db.faction.findFirst({
         where: { initialPlanets: { some: { id } } },
       }),
     ]);
@@ -165,10 +163,10 @@ export const getPlanetCampaigns = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, campaigns] = await Promise.all([
-      prisma.campaign.count({
+      db.campaign.count({
         where: { planetId: id },
       }),
-      prisma.campaign.findMany({
+      db.campaign.findMany({
         ...(query ?? {}),
         where: { ...(query.where as any), planetId: id },
       }),
@@ -200,10 +198,10 @@ export const getPlanetOrders = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, orders] = await Promise.all([
-      prisma.order.count({
+      db.order.count({
         where: { planetId: id },
       }),
-      prisma.order.findMany({
+      db.order.findMany({
         ...(query ?? {}),
         where: { ...(query.where as any), planetId: id },
       }),
@@ -240,7 +238,7 @@ export const getPlanetStatistics = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const stats = await prisma.stats.findFirst({
+    const stats = await db.stats.findFirst({
       ...(query as any),
       where: { planet: { id } },
     });

--- a/src/controllers/reports.ts
+++ b/src/controllers/reports.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getReportById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getReportById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const report = await prisma.news.findUnique({
+    const report = await db.news.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllReports = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, reports] = await Promise.all([
-      prisma.news.count({ where: query.where }),
-      prisma.news.findMany(query),
+      db.news.count({ where: query.where }),
+      db.news.findMany(query),
     ]);
 
     return ctx.json({

--- a/src/controllers/sectors.ts
+++ b/src/controllers/sectors.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getSectorById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getSectorById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const sector = await prisma.sector.findUnique({
+    const sector = await db.sector.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -47,8 +45,8 @@ export const getAllSectors = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, sectors] = await Promise.all([
-      prisma.sector.count({ where: query.where }),
-      prisma.sector.findMany(query),
+      db.sector.count({ where: query.where }),
+      db.sector.findMany(query),
     ]);
 
     return ctx.json({
@@ -76,8 +74,8 @@ export const getPlanetsBySector = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, planets] = await Promise.all([
-      prisma.planet.count({ where: query.where }),
-      prisma.planet.findMany({
+      db.planet.count({ where: query.where }),
+      db.planet.findMany({
         ...query,
         where: {
           ...(query.where ?? {}),

--- a/src/controllers/statistics.ts
+++ b/src/controllers/statistics.ts
@@ -1,11 +1,10 @@
 import type { Context } from "hono";
-import { PrismaClient, type Stats } from "@prisma/client";
+import type { Stats } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getStatisticById = await witCache(async (ctx: Context) => {
   try {
@@ -28,12 +27,12 @@ export const getStatisticById = await witCache(async (ctx: Context) => {
     let statistic: Stats | null = null;
 
     if (id === "galaxy") {
-      statistic = await prisma.stats.findFirst({
+      statistic = await db.stats.findFirst({
         ...(query as any),
         where: { planet: { is: null } },
       });
     } else {
-      statistic = await prisma.stats.findUnique({
+      statistic = await db.stats.findUnique({
         ...(query as any),
         where: { id },
       });
@@ -69,8 +68,8 @@ export const getAllStatistics = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, statistics] = await Promise.all([
-      prisma.stats.count({ where: query.where }),
-      prisma.stats.findMany(query),
+      db.stats.count({ where: query.where }),
+      db.stats.findMany(query),
     ]);
 
     return ctx.json({

--- a/src/controllers/stratagems.ts
+++ b/src/controllers/stratagems.ts
@@ -1,11 +1,9 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import parseIntParam from "utils/params";
 import witCache from "utils/request-cache";
 import parseQueryParams from "utils/query";
-
-const prisma = new PrismaClient();
 
 export const getStratagemById = await witCache(async (ctx: Context) => {
   try {
@@ -18,7 +16,7 @@ export const getStratagemById = await witCache(async (ctx: Context) => {
     delete (query as any).skip;
     delete (query as any).take;
 
-    const stratagem = await prisma.stratagem.findUnique({
+    const stratagem = await db.stratagem.findUnique({
       ...(query as any),
       where: { id },
     });
@@ -52,8 +50,8 @@ export const getAllStratagems = await witCache(async (ctx: Context) => {
     const query = await parseQueryParams(ctx);
 
     const [count, stratagems] = await Promise.all([
-      prisma.stratagem.count({ where: query.where }),
-      prisma.stratagem.findMany(query),
+      db.stratagem.count({ where: query.where }),
+      db.stratagem.findMany(query),
     ]);
 
     return ctx.json({

--- a/src/controllers/war.ts
+++ b/src/controllers/war.ts
@@ -1,13 +1,11 @@
 import type { Context } from "hono";
-import { PrismaClient } from "@prisma/client";
 
+import { db } from "utils/database";
 import witCache from "utils/request-cache";
-
-const prisma = new PrismaClient();
 
 export const getCurrentWar = await witCache(async (ctx: Context) => {
   try {
-    const war = await prisma.war.findFirst();
+    const war = await db.war.findFirst();
 
     return ctx.json({
       data: war,

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { db: PrismaClient };
+
+export const db = globalForPrisma.db || new PrismaClient();
+if (process.env.NODE_ENV !== "production") globalForPrisma.db = db;


### PR DESCRIPTION
## Description

Recent deployment monitoring has shown that we waste a lot of unnecessary memory by not properly re-using a single Prisma instance but creating a new one for each route handler. Following fix has been implemented:

```typescript
// utils/database.ts

import { PrismaClient } from "@prisma/client";

const globalForPrisma = globalThis as unknown as { db: PrismaClient };

// prevent hot reloading from creating new instances of PrismaClient
export const db = globalForPrisma.db || new PrismaClient();
if (process.env.NODE_ENV !== "production") globalForPrisma.db = db;

```

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
