### PR TITLE
feat: add planet biomes and environmental effects

### DIFF
--- a/prisma/migrations/20240416070907_biomes/migration.sql
+++ b/prisma/migrations/20240416070907_biomes/migration.sql
@@ -1,0 +1,84 @@
+/*
+  Warnings:
+
+  - Added the required column `biomeId` to the `Planet` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateTable
+CREATE TABLE "Biome" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Effect" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Effect" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+    CONSTRAINT "_Effect_A_fkey" FOREIGN KEY ("A") REFERENCES "Effect" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_Effect_B_fkey" FOREIGN KEY ("B") REFERENCES "Planet" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Planet" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" BIGINT NOT NULL,
+    "name" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "sectorId" INTEGER NOT NULL,
+    "health" INTEGER NOT NULL,
+    "maxHealth" INTEGER NOT NULL,
+    "players" INTEGER NOT NULL,
+    "disabled" BOOLEAN NOT NULL,
+    "regeneration" INTEGER NOT NULL,
+    "liberation" REAL NOT NULL,
+    "liberationRate" REAL NOT NULL,
+    "liberationState" TEXT NOT NULL,
+    "initialOwnerId" INTEGER NOT NULL,
+    "positionX" REAL NOT NULL,
+    "positionY" REAL NOT NULL,
+    "globalEventId" INTEGER,
+    "biomeId" INTEGER NOT NULL,
+    "statisticId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Planet_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_sectorId_fkey" FOREIGN KEY ("sectorId") REFERENCES "Sector" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_initialOwnerId_fkey" FOREIGN KEY ("initialOwnerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_globalEventId_fkey" FOREIGN KEY ("globalEventId") REFERENCES "GlobalEvent" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Planet_biomeId_fkey" FOREIGN KEY ("biomeId") REFERENCES "Biome" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_statisticId_fkey" FOREIGN KEY ("statisticId") REFERENCES "Stats" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Planet" ("createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "liberation", "liberationRate", "liberationState", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt") SELECT "createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "liberation", "liberationRate", "liberationState", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt" FROM "Planet";
+DROP TABLE "Planet";
+ALTER TABLE "new_Planet" RENAME TO "Planet";
+CREATE UNIQUE INDEX "Planet_index_key" ON "Planet"("index");
+CREATE UNIQUE INDEX "Planet_statisticId_key" ON "Planet"("statisticId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Biome_index_key" ON "Biome"("index");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Effect_index_key" ON "Effect"("index");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Effect_AB_unique" ON "_Effect"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Effect_B_index" ON "_Effect"("B");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,9 @@ model Planet {
   homeWorld       HomeWorld[]  @relation("HomeWorld")
   attacking       Attack[]     @relation("Attack")
   defending       Attack[]     @relation("Defend")
+  effects         Effect[]     @relation("Effect")
+  biome           Biome        @relation(fields: [biomeId], references: [id])
+  biomeId         Int
   statistic       Stats?       @relation(fields: [statisticId], references: [id])
   statisticId     Int?         @unique
   createdAt       DateTime     @default(now())
@@ -215,6 +218,26 @@ model Assignment {
   description String
   reward      Reward   @relation(fields: [rewardId], references: [id])
   rewardId    Int      @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Biome {
+  id          Int      @id @default(autoincrement())
+  index       String   @unique
+  name        String
+  description String
+  planets     Planet[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Effect {
+  id          Int      @id @default(autoincrement())
+  index       String   @unique
+  name        String
+  description String
+  planets     Planet[] @relation("Effect")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }

--- a/src/controllers/biomes.ts
+++ b/src/controllers/biomes.ts
@@ -1,0 +1,92 @@
+import type { Context } from "hono";
+
+import { db } from "utils/database";
+import parseIntParam from "utils/params";
+import witCache from "utils/request-cache";
+import parseQueryParams from "utils/query";
+
+export const getBiomeById = await witCache(async (ctx: Context) => {
+  try {
+    const id = parseIntParam(ctx, "id");
+    const query = await parseQueryParams(ctx);
+
+    delete query.orderBy;
+    delete query.where;
+    delete query.orderBy;
+    delete (query as any).skip;
+    delete (query as any).take;
+
+    const biome = await db.biome.findUnique({
+      ...(query as any),
+      where: { id },
+    });
+
+    if (!biome) {
+      ctx.status(404);
+      return ctx.json({
+        data: null,
+        error: { details: [`Biome with id (${id}) not found`] },
+      });
+    }
+
+    return ctx.json({ data: biome, error: null });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});
+
+export const getAllBiomes = await witCache(async (ctx: Context) => {
+  try {
+    const query = await parseQueryParams(ctx);
+
+    const [count, biomes] = await Promise.all([
+      db.biome.count({ where: query.where }),
+      db.biome.findMany(query),
+    ]);
+
+    return ctx.json({
+      data: biomes,
+      error: null,
+      pagination: {
+        page: query.skip / query.take + 1,
+        pageSize: query.take,
+        pageCount: Math.ceil((count as number) / query.take),
+        total: count,
+      },
+    });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});
+
+export const getPlanetsByBiome = await witCache(async (ctx: Context) => {
+  try {
+    const id = parseIntParam(ctx, "id");
+    const query = await parseQueryParams(ctx);
+
+    delete query.where;
+    const planets = await db.planet.findMany({
+      ...query,
+      where: { biome: { id } },
+    });
+
+    return ctx.json({ data: planets, error: null });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});

--- a/src/controllers/effects.ts
+++ b/src/controllers/effects.ts
@@ -1,0 +1,92 @@
+import type { Context } from "hono";
+
+import { db } from "utils/database";
+import parseIntParam from "utils/params";
+import witCache from "utils/request-cache";
+import parseQueryParams from "utils/query";
+
+export const getEffectById = await witCache(async (ctx: Context) => {
+  try {
+    const id = parseIntParam(ctx, "id");
+    const query = await parseQueryParams(ctx);
+
+    delete query.orderBy;
+    delete query.where;
+    delete query.orderBy;
+    delete (query as any).skip;
+    delete (query as any).take;
+
+    const effect = await db.effect.findUnique({
+      ...(query as any),
+      where: { id },
+    });
+
+    if (!effect) {
+      ctx.status(404);
+      return ctx.json({
+        data: null,
+        error: { details: [`Effect with id (${id}) not found`] },
+      });
+    }
+
+    return ctx.json({ data: effect, error: null });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});
+
+export const getAllEffects = await witCache(async (ctx: Context) => {
+  try {
+    const query = await parseQueryParams(ctx);
+
+    const [count, effects] = await Promise.all([
+      db.effect.count({ where: query.where }),
+      db.effect.findMany(query),
+    ]);
+
+    return ctx.json({
+      data: effects,
+      error: null,
+      pagination: {
+        page: query.skip / query.take + 1,
+        pageSize: query.take,
+        pageCount: Math.ceil((count as number) / query.take),
+        total: count,
+      },
+    });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});
+
+export const getPlanetsByEffect = await witCache(async (ctx: Context) => {
+  try {
+    const id = parseIntParam(ctx, "id");
+    const query = await parseQueryParams(ctx);
+
+    delete query.where;
+    const planets = await db.planet.findMany({
+      ...query,
+      where: { effects: { some: { id } } },
+    });
+
+    return ctx.json({ data: planets, error: null });
+  } catch (error: any) {
+    console.error(error);
+    ctx.status(500);
+    return ctx.json({
+      data: null,
+      error: { details: [error.message] },
+    });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ import cache from "middleware/request-cache";
 import rateLimit from "middleware/rate-limit";
 
 import wars from "routes/war";
+import biomes from "routes/biomes";
 import orders from "routes/orders";
 import events from "routes/events";
+import effects from "routes/effects";
 import planets from "routes/planets";
 import sectors from "routes/sectors";
 import reports from "routes/reports";
@@ -32,10 +34,12 @@ app.use(cache);
 // routes for the api
 const routes = [
   wars,
+  biomes,
   events,
   orders,
   reports,
   planets,
+  effects,
   sectors,
   attacks,
   factions,

--- a/src/routes/biomes.ts
+++ b/src/routes/biomes.ts
@@ -1,0 +1,9 @@
+import type { Hono } from "hono";
+
+import * as Biomes from "controllers/biomes";
+
+export default async function biomes(app: Hono) {
+  app.get("/biomes", Biomes.getAllBiomes);
+  app.get("/biomes/:id", Biomes.getBiomeById);
+  app.get("/biomes/:id/planets", Biomes.getPlanetsByBiome);
+}

--- a/src/routes/effects.ts
+++ b/src/routes/effects.ts
@@ -1,0 +1,9 @@
+import type { Hono } from "hono";
+
+import * as Effects from "controllers/effects";
+
+export default async function effects(app: Hono) {
+  app.get("/effects", Effects.getAllEffects);
+  app.get("/effects/:id", Effects.getEffectById);
+  app.get("/effects/:id/planets", Effects.getPlanetsByEffect);
+}

--- a/src/static/json/biomes.json
+++ b/src/static/json/biomes.json
@@ -1,0 +1,70 @@
+{
+  "unknown": {
+    "name": "Unknown",
+    "description": "This planet's biome is unknown at this time."
+  },
+  "rainforest": {
+    "name": "Rainforest",
+    "description": "The strange subversion of photosynthesis that sustains the oddly-hued flora that flourishes on this planet remains an intriguing mystery to Super Earth's greatest exo-biologists."
+  },
+  "ethereal": {
+    "name": "Ethereal",
+    "description": "This world teems with ethereal, boundless, and peculiar plant life that spreads silent and uninterrupted across its entire surface."
+  },
+  "jungle": {
+    "name": "Jungle",
+    "description": "Abundant with life, this wet planet is covered in deep oceans, thick forests, and tall grasses."
+  },
+  "moon": {
+    "name": "Moon",
+    "description": "A rocky, lonely moon with extremely valuable mineral deposits underneath the surface."
+  },
+  "desert": {
+    "name": "Desert",
+    "description": "A desert planet prone to unpredictable and dangerous,sand twisters."
+  },
+  "winter": {
+    "name": "Winter",
+    "description": "Submerged in eternal winter, this world's frosty peaks glimmer in the light of its too-distant star."
+  },
+  "highlands": {
+    "name": "Highlands",
+    "description": "Rocky outcroppings punctuate fields of tall grass in a planet dominated by misty highland terrain."
+  },
+  "icemoss": {
+    "name": "Icemoss",
+    "description": "Ice and moss-covered rock can be found across most of the surface of this planet."
+  },
+  "icemoss_special": {
+    "name": "Icemoss Special",
+    "description": "Ice and moss-covered rock can be found across most of the surface of this planet."
+  },
+  "tundra": {
+    "name": "Tundra",
+    "description": "A perenially chilly climate has allowed short, colourful shrubs to flourish across this planet's surface."
+  },
+  "swamp": {
+    "name": "Swamp",
+    "description": "The lifeless grey of this planet is interrupted only by the violet flowers that grow from strange, parasitic outcroppings."
+  },
+  "desolate": {
+    "name": "Desolate",
+    "description": "Scorching temperatures, high winds, and low precipitation cause a near-constant cycle of fires to sweep this planet, punctuated by short bursts of lush rebirth between infernos."
+  },
+  "crimsonmoor": {
+    "name": "Crimsonmoor",
+    "description": "A crimson algae has propagated wildly across this entire planet, coating its rocky hills with a constant red that masks the spilt blood of the heroes who defend it from tyranny."
+  },
+  "canyon": {
+    "name": "Canyon",
+    "description": "This arid, rocky biome covering this world has driven the evolution of exceptionally efficient water usage in its various organisms."
+  },
+  "mesa": {
+    "name": "Mesa",
+    "description": "A blazing-hot desert planet, it's rocky mesas are the sole interruptions to the endless sea of dunes."
+  },
+  "toxic": {
+    "name": "Toxic",
+    "description": "Dense, toxic fumes from deep within the planet's crust seep out of cracks in the earth and coat the ground in a sickly haze."
+  }
+}

--- a/src/static/json/effects.json
+++ b/src/static/json/effects.json
@@ -1,1 +1,54 @@
-{}
+{
+  "none": {
+    "name": "None",
+    "description": "This planet's environment is not yet known, or has no environmental modifiers."
+  },
+  "extreme_cold": {
+    "name": "Extreme Cold",
+    "description": "Icy temperatures reduce rate of fire and delay heat buildup in weapons."
+  },
+  "thick_fog": {
+    "name": "Thick Fog",
+    "description": "Dense fog lightly reduce visibility for both enemy and friendly units."
+  },
+  "rainstorms": {
+    "name": "Rainstorms",
+    "description": "Torrential rainstorms reduce visibility."
+  },
+  "intense_heat": {
+    "name": "Intense Heat",
+    "description": "High temperatures increase stamina drain and speed up heat buildup in weapons."
+  },
+  "tremors": {
+    "name": "Tremors",
+    "description": "Frequent earthquakes stun players and enemies alike."
+  },
+  "blizzards": {
+    "name": "Blizzards",
+    "description": "Intense blizzard reduce mobility and moderately reduce visibility for both enemy and friendly units."
+  },
+  "meteor_storms": {
+    "name": "Meteor Storms",
+    "description": "Meteors impact the surface causing massive damage"
+  },
+  "sandstorms": {
+    "name": "Sandstorms",
+    "description": "Dense sandstorms reduce mobility and greatly reduce visibility for both enemy and friendly units."
+  },
+  "ion_storms": {
+    "name": "Ion Storms",
+    "description": "Ion storms intermittently disable Stratagems."
+  },
+  "acid_storms": {
+    "name": "Acid Storms",
+    "description": "Violent acid storms reduce visibility."
+  },
+  "volcanic_activity": {
+    "name": "Volcanic Activity",
+    "description": "Volcanoes throw burning rocks around this planet."
+  },
+  "fire_tornadoes": {
+    "name": "Fire Tornadoes",
+    "description": "Planet is ravaged by deadly fire tornadoes."
+  }
+}

--- a/src/static/json/planets.json
+++ b/src/static/json/planets.json
@@ -1,263 +1,1307 @@
 {
-  "0": "Super Earth",
-  "1": "Klen Dahth II",
-  "2": "Pathfinder V",
-  "3": "Widow's Harbor",
-  "4": "New Haven",
-  "5": "Pilen V",
-  "6": "Hydrofall Prime",
-  "7": "Zea Rugosia",
-  "8": "Darrowsport",
-  "9": "Fornskogur II",
-  "10": "Midasburg",
-  "11": "Cerberus Iiic",
-  "12": "Prosperity Falls",
-  "13": "Okul VI",
-  "14": "Martyr's Bay",
-  "15": "Freedom Peak",
-  "16": "Fort Union",
-  "17": "Kelvinor",
-  "18": "Wraith",
-  "19": "Igla",
-  "20": "New Kiruna",
-  "21": "Fort Justice",
-  "22": "Zegema Paradise",
-  "23": "Providence",
-  "24": "Primordia",
-  "25": "Sulfura",
-  "26": "Nublaria I",
-  "27": "Krakatwo",
-  "28": "Volterra",
-  "29": "Crucible",
-  "30": "Veil",
-  "31": "Marre IV",
-  "32": "Fort Sanctuary",
-  "33": "Seyshel Beach",
-  "34": "Hellmire",
-  "35": "Effluvia",
-  "36": "Solghast",
-  "37": "Diluvia",
-  "38": "Viridia Prime",
-  "39": "Obari",
-  "40": "Myradesh",
-  "41": "Atrama",
-  "42": "Emeria",
-  "43": "Barabos",
-  "44": "Fenmire",
-  "45": "Mastia",
-  "46": "Shallus",
-  "47": "Krakabos",
-  "48": "Iridica",
-  "49": "Azterra",
-  "50": "Azur Secundus",
-  "51": "Ivis",
-  "52": "Slif",
-  "53": "Caramoor",
-  "54": "Kharst",
-  "55": "Eukoria",
-  "56": "Myrium",
-  "57": "Kerth Secundus",
-  "58": "Parsh",
-  "59": "Reaf",
-  "60": "Irulta",
-  "61": "Emorath",
-  "62": "Ilduna Prime",
-  "63": "Maw",
-  "64": "Meridia",
-  "65": "Borea",
-  "66": "Curia",
-  "67": "Tarsh",
-  "68": "Shelt",
-  "69": "Imber",
-  "70": "Blistica",
-  "71": "Ratch",
-  "72": "Julheim",
-  "73": "Valgaard",
-  "74": "Arkturus",
-  "75": "Esker",
-  "76": "Terrek",
-  "77": "Cirrus",
-  "78": "Crimsica",
-  "79": "Heeth",
-  "80": "Veld",
-  "81": "Alta V",
-  "82": "Ursica XI",
-  "83": "Inari",
-  "84": "Skaash",
-  "85": "Moradesh",
-  "86": "Rasp",
-  "87": "Bashyr",
-  "88": "Regnus",
-  "89": "Mog",
-  "90": "Valmox",
-  "91": "Iro",
-  "92": "Grafmere",
-  "93": "New Stockholm",
-  "94": "Oasis",
-  "95": "Genesis Prime",
-  "96": "Outpost 32",
-  "97": "Calypso",
-  "98": "Elysian Meadows",
-  "99": "Alderidge Cove",
-  "100": "Trandor",
-  "101": "East Iridium Trading Bay",
-  "102": "Liberty Ridge",
-  "103": "Baldrick Prime",
-  "104": "The Weir",
-  "105": "Kuper",
-  "106": "Oslo Station",
-  "107": "Pöpli IX",
-  "108": "Gunvald",
-  "109": "Dolph",
-  "110": "Bekvam III",
-  "111": "Duma Tyr",
-  "112": "Vernen Wells",
-  "113": "Aesir Pass",
-  "114": "Aurora Bay",
-  "115": "Penta",
-  "116": "Gaellivare",
-  "117": "Vog-sojoth",
-  "118": "Kirrik",
-  "119": "Mortax Prime",
-  "120": "Wilford Station",
-  "121": "Pioneer II",
-  "122": "Erson Sands",
-  "123": "Socorro III",
-  "124": "Bore Rock",
-  "125": "Fenrir III",
-  "126": "Turing",
-  "127": "Angel's Venture",
-  "128": "Darius II",
-  "129": "Acamar IV",
-  "130": "Achernar Secundus",
-  "131": "Achird III",
-  "132": "Acrab XI",
-  "133": "Acrux IX",
-  "134": "Acubens Prime",
-  "135": "Adhara",
-  "136": "Afoyay Bay",
-  "137": "Ain-5",
-  "138": "Alairt III",
-  "139": "Alamak VII",
-  "140": "Alaraph",
-  "141": "Alathfar XI",
-  "142": "Andar",
-  "143": "Asperoth Prime",
-  "144": "Bellatrix",
-  "145": "Botein",
-  "146": "Osupsam",
-  "147": "Brink-2",
-  "148": "Bunda Secundus",
-  "149": "Canopus",
-  "150": "Caph",
-  "151": "Castor",
-  "152": "Durgen",
-  "153": "Draupnir",
-  "154": "Mort",
-  "155": "Ingmar",
-  "156": "Charbal-VII",
-  "157": "Charon Prime",
-  "158": "Choepessa IV",
-  "159": "Choohe",
-  "160": "Chort Bay",
-  "161": "Claorell",
-  "162": "Clasa",
-  "163": "Demiurg",
-  "164": "Deneb Secundus",
-  "165": "Electra Bay",
-  "166": "Enuliale",
-  "167": "Epsilon Phoencis VI",
-  "168": "Erata Prime",
-  "169": "Estanu",
-  "170": "Fori Prime",
-  "171": "Gacrux",
-  "172": "Gar Haren",
-  "173": "Gatria",
-  "174": "Gemma",
-  "175": "Grand Errant",
-  "176": "Hadar",
-  "177": "Haka",
-  "178": "Haldus",
-  "179": "Halies Port",
-  "180": "Herthon Secundus",
-  "181": "Hesoe Prime",
-  "182": "Heze Bay",
-  "183": "Hort",
-  "184": "Hydrobius",
-  "185": "Karlia",
-  "186": "Keid",
-  "187": "Khandark",
-  "188": "Klaka 5",
-  "189": "Kneth Port",
-  "190": "Kraz",
-  "191": "Kuma",
-  "192": "Lastofe",
-  "193": "Leng Secundus",
-  "194": "Lesath",
-  "195": "Maia",
-  "196": "Malevelon Creek",
-  "197": "Mantes",
-  "198": "Marfark",
-  "199": "Martale",
-  "200": "Matar Bay",
-  "201": "Meissa",
-  "202": "Mekbuda",
-  "203": "Menkent",
-  "204": "Merak",
-  "205": "Merga IV",
-  "206": "Minchir",
-  "207": "Mintoria",
-  "208": "Mordia 9",
-  "209": "Nabatea Secundus",
-  "210": "Navi VII",
-  "211": "Nivel 43",
-  "212": "Oshaune",
-  "213": "Overgoe Prime",
-  "214": "Pandion-XXIV",
-  "215": "Partion",
-  "216": "Peacock",
-  "217": "Phact Bay",
-  "218": "Pherkad Secundus",
-  "219": "Polaris Prime",
-  "220": "Pollux 31",
-  "221": "Prasa",
-  "222": "Propus",
-  "223": "Ras Algethi",
-  "224": "Rd-4",
-  "225": "Rogue 5",
-  "226": "Rirga Bay",
-  "227": "Seasse",
-  "228": "Senge 23",
-  "229": "Setia",
-  "230": "Shete",
-  "231": "Siemnot",
-  "232": "Sirius",
-  "233": "Skat Bay",
-  "234": "Spherion",
-  "235": "Stor Tha Prime",
-  "236": "Stout",
-  "237": "Termadon",
-  "238": "Tibit",
-  "239": "Tien Kwan",
-  "240": "Troost",
-  "241": "Ubanea",
-  "242": "Ustotu",
-  "243": "Vandalon IV",
-  "244": "Varylia 5",
-  "245": "Wasat",
-  "246": "Vega Bay",
-  "247": "Wezen",
-  "248": "Vindemitarix Prime",
-  "249": "X-45",
-  "250": "Yed Prior",
-  "251": "Zefia",
-  "252": "Zosma",
-  "253": "Zzaniah Prime",
-  "254": "Skitter",
-  "255": "Euphoria III",
-  "256": "Diaspora X",
-  "257": "Gemstone Bluffs",
-  "258": "Zagon Prime",
-  "259": "Omicron",
-  "260": "Cyberstan"
+  "0": {
+    "name": "Super Earth",
+    "biome": "unknown",
+    "effects": ["none"]
+  },
+  "1": {
+    "name": "Klen Dahth II",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "2": {
+    "name": "Pathfinder V",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "3": {
+    "name": "Widow's Harbor",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "4": {
+    "name": "New Haven",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "5": {
+    "name": "Pilen V",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "6": {
+    "name": "Hydrofall Prime",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "7": {
+    "name": "Zea Rugosia",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "8": {
+    "name": "Darrowsport",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "9": {
+    "name": "Fornskogur II",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "10": {
+    "name": "Midasburg",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "11": {
+    "name": "Cerberus Iiic",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "12": {
+    "name": "Prosperity Falls",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "13": {
+    "name": "Okul VI",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "14": {
+    "name": "Martyr's Bay",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "15": {
+    "name": "Freedom Peak",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "16": {
+    "name": "Fort Union",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "17": {
+    "name": "Kelvinor",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "18": {
+    "name": "Wraith",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "19": {
+    "name": "Igla",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "20": {
+    "name": "New Kiruna",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "21": {
+    "name": "Fort Justice",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "22": {
+    "name": "Zegema Paradise",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "23": {
+    "name": "Providence",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "24": {
+    "name": "Primordia",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "25": {
+    "name": "Sulfura",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "26": {
+    "name": "Nublaria I",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "27": {
+    "name": "Krakatwo",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "28": {
+    "name": "Volterra",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "29": {
+    "name": "Crucible",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "30": {
+    "name": "Veil",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "31": {
+    "name": "Marre IV",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "32": {
+    "name": "Fort Sanctuary",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "33": {
+    "name": "Seyshel Beach",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "34": {
+    "name": "Hellmire",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "35": {
+    "name": "Effluvia",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "36": {
+    "name": "Solghast",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "37": {
+    "name": "Diluvia",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "38": {
+    "name": "Viridia Prime",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "39": {
+    "name": "Obari",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "40": {
+    "name": "Myradesh",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "41": {
+    "name": "Atrama",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "42": {
+    "name": "Emeria",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "43": {
+    "name": "Barabos",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "44": {
+    "name": "Fenmire",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "45": {
+    "name": "Mastia",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "46": {
+    "name": "Shallus",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "47": {
+    "name": "Krakabos",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "48": {
+    "name": "Iridica",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "49": {
+    "name": "Azterra",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "50": {
+    "name": "Azur Secundus",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "51": {
+    "name": "Ivis",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "52": {
+    "name": "Slif",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "53": {
+    "name": "Caramoor",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "54": {
+    "name": "Kharst",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "55": {
+    "name": "Eukoria",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "56": {
+    "name": "Myrium",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "57": {
+    "name": "Kerth Secundus",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "58": {
+    "name": "Parsh",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "59": {
+    "name": "Reaf",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "60": {
+    "name": "Irulta",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "61": {
+    "name": "Emorath",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "62": {
+    "name": "Ilduna Prime",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "63": {
+    "name": "Maw",
+    "biome": "desolate",
+    "effects": ["intense_heat"]
+  },
+  "64": {
+    "name": "Meridia",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "65": {
+    "name": "Borea",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "66": {
+    "name": "Curia",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "67": {
+    "name": "Tarsh",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "68": {
+    "name": "Shelt",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "69": {
+    "name": "Imber",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "70": {
+    "name": "Blistica",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "71": {
+    "name": "Ratch",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "72": {
+    "name": "Julheim",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "73": {
+    "name": "Valgaard",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "74": {
+    "name": "Arkturus",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "75": {
+    "name": "Esker",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "76": {
+    "name": "Terrek",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "77": {
+    "name": "Cirrus",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "78": {
+    "name": "Crimsica",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "79": {
+    "name": "Heeth",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "80": {
+    "name": "Veld",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "81": {
+    "name": "Alta V",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "82": {
+    "name": "Ursica XI",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "83": {
+    "name": "Inari",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "84": {
+    "name": "Skaash",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "85": {
+    "name": "Moradesh",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "86": {
+    "name": "Rasp",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "87": {
+    "name": "Bashyr",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "88": {
+    "name": "Regnus",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "89": {
+    "name": "Mog",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "90": {
+    "name": "Valmox",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "91": {
+    "name": "Iro",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "92": {
+    "name": "Grafmere",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "93": {
+    "name": "New Stockholm",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "94": {
+    "name": "Oasis",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "95": {
+    "name": "Genesis Prime",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "96": {
+    "name": "Outpost 32",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "97": {
+    "name": "Calypso",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "98": {
+    "name": "Elysian Meadows",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "99": {
+    "name": "Alderidge Cove",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "100": {
+    "name": "Trandor",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "101": {
+    "name": "East Iridium Trading Bay",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "102": {
+    "name": "Liberty Ridge",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "103": {
+    "name": "Baldrick Prime",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "104": {
+    "name": "The Weir",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "105": {
+    "name": "Kuper",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "106": {
+    "name": "Oslo Station",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "107": {
+    "name": "Pöpli IX",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "108": {
+    "name": "Gunvald",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "109": {
+    "name": "Dolph",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "110": {
+    "name": "Bekvam III",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "111": {
+    "name": "Duma Tyr",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "112": {
+    "name": "Vernen Wells",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "113": {
+    "name": "Aesir Pass",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "114": {
+    "name": "Aurora Bay",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "115": {
+    "name": "Penta",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "116": {
+    "name": "Gaellivare",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "117": {
+    "name": "Vog-sojoth",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "118": {
+    "name": "Kirrik",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "119": {
+    "name": "Mortax Prime",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "120": {
+    "name": "Wilford Station",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "121": {
+    "name": "Pioneer II",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "122": {
+    "name": "Erson Sands",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "123": {
+    "name": "Socorro III",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "124": {
+    "name": "Bore Rock",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "125": {
+    "name": "Fenrir III",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "126": {
+    "name": "Turing",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "127": {
+    "name": "Angel's Venture",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "128": {
+    "name": "Darius II",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "129": {
+    "name": "Acamar IV",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "130": {
+    "name": "Achernar Secundus",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "131": {
+    "name": "Achird III",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "132": {
+    "name": "Acrab XI",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "133": {
+    "name": "Acrux IX",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "134": {
+    "name": "Acubens Prime",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "135": {
+    "name": "Adhara",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "136": {
+    "name": "Afoyay Bay",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "137": {
+    "name": "Ain-5",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "138": {
+    "name": "Alairt III",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "139": {
+    "name": "Alamak VII",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "140": {
+    "name": "Alaraph",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "141": {
+    "name": "Alathfar XI",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "142": {
+    "name": "Andar",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "143": {
+    "name": "Asperoth Prime",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "144": {
+    "name": "Bellatrix",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "145": {
+    "name": "Botein",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "146": {
+    "name": "Osupsam",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "147": {
+    "name": "Brink-2",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "148": {
+    "name": "Bunda Secundus",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "149": {
+    "name": "Canopus",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "150": {
+    "name": "Caph",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "151": {
+    "name": "Castor",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "152": {
+    "name": "Durgen",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "153": {
+    "name": "Draupnir",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "154": {
+    "name": "Mort",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "155": {
+    "name": "Ingmar",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "156": {
+    "name": "Charbal-VII",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "157": {
+    "name": "Charon Prime",
+    "biome": "crimsonmoor",
+    "effects": ["intense_heat"]
+  },
+  "158": {
+    "name": "Choepessa IV",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "159": {
+    "name": "Choohe",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "160": {
+    "name": "Chort Bay",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "161": {
+    "name": "Claorell",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "162": {
+    "name": "Clasa",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "163": {
+    "name": "Demiurg",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "164": {
+    "name": "Deneb Secundus",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "165": {
+    "name": "Electra Bay",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "166": {
+    "name": "Enuliale",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "167": {
+    "name": "Epsilon Phoencis VI",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "168": {
+    "name": "Erata Prime",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "169": {
+    "name": "Estanu",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "170": {
+    "name": "Fori Prime",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "171": {
+    "name": "Gacrux",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "172": {
+    "name": "Gar Haren",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "173": {
+    "name": "Gatria",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "174": {
+    "name": "Gemma",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "175": {
+    "name": "Grand Errant",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "176": {
+    "name": "Hadar",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "177": {
+    "name": "Haka",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "178": {
+    "name": "Haldus",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "179": {
+    "name": "Halies Port",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "180": {
+    "name": "Herthon Secundus",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "181": {
+    "name": "Hesoe Prime",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "182": {
+    "name": "Heze Bay",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "183": {
+    "name": "Hort",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "184": {
+    "name": "Hydrobius",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "185": {
+    "name": "Karlia",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "186": {
+    "name": "Keid",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "187": {
+    "name": "Khandark",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "188": {
+    "name": "Klaka 5",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "189": {
+    "name": "Kneth Port",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "190": {
+    "name": "Kraz",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "191": {
+    "name": "Kuma",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "192": {
+    "name": "Lastofe",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "193": {
+    "name": "Leng Secundus",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "194": {
+    "name": "Lesath",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "195": {
+    "name": "Maia",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "196": {
+    "name": "Malevelon Creek",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "197": {
+    "name": "Mantes",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "198": {
+    "name": "Marfark",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "199": {
+    "name": "Martale",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "200": {
+    "name": "Matar Bay",
+    "biome": "highlands",
+    "effects": ["rainstorms"]
+  },
+  "201": {
+    "name": "Meissa",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "202": {
+    "name": "Mekbuda",
+    "biome": "canyon",
+    "effects": ["extreme_cold"]
+  },
+  "203": {
+    "name": "Menkent",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "204": {
+    "name": "Merak",
+    "biome": "rainforest",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "205": {
+    "name": "Merga IV",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "206": {
+    "name": "Minchir",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "207": {
+    "name": "Mintoria",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "208": {
+    "name": "Mordia 9",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "209": {
+    "name": "Nabatea Secundus",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "210": {
+    "name": "Navi VII",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "211": {
+    "name": "Nivel 43",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "212": {
+    "name": "Oshaune",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "213": {
+    "name": "Overgoe Prime",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "214": {
+    "name": "Pandion-XXIV",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "215": {
+    "name": "Partion",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "216": {
+    "name": "Peacock",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "217": {
+    "name": "Phact Bay",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "218": {
+    "name": "Pherkad Secundus",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "219": {
+    "name": "Polaris Prime",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "220": {
+    "name": "Pollux 31",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "221": {
+    "name": "Prasa",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "222": {
+    "name": "Propus",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "223": {
+    "name": "Ras Algethi",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "224": {
+    "name": "Rd-4",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "225": {
+    "name": "Rogue 5",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "226": {
+    "name": "Rirga Bay",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "227": {
+    "name": "Seasse",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "228": {
+    "name": "Senge 23",
+    "biome": "canyon",
+    "effects": ["tremors"]
+  },
+  "229": {
+    "name": "Setia",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "230": {
+    "name": "Shete",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "231": {
+    "name": "Siemnot",
+    "biome": "rainforest",
+    "effects": ["ion_storms"]
+  },
+  "232": {
+    "name": "Sirius",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "233": {
+    "name": "Skat Bay",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "234": {
+    "name": "Spherion",
+    "biome": "jungle",
+    "effects": ["volcanic_activity", "rainstorms"]
+  },
+  "235": {
+    "name": "Stor Tha Prime",
+    "biome": "icemoss",
+    "effects": ["extreme_cold"]
+  },
+  "236": {
+    "name": "Stout",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "237": {
+    "name": "Termadon",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "238": {
+    "name": "Tibit",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "239": {
+    "name": "Tien Kwan",
+    "biome": "icemoss_special",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "240": {
+    "name": "Troost",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "241": {
+    "name": "Ubanea",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "242": {
+    "name": "Ustotu",
+    "biome": "desert",
+    "effects": ["intense_heat", "tremors"]
+  },
+  "243": {
+    "name": "Vandalon IV",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "244": {
+    "name": "Varylia 5",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "245": {
+    "name": "Wasat",
+    "biome": "toxic",
+    "effects": ["intense_heat", "acid_storms"]
+  },
+  "246": {
+    "name": "Vega Bay",
+    "biome": "winter",
+    "effects": ["extreme_cold", "blizzards"]
+  },
+  "247": {
+    "name": "Wezen",
+    "biome": "desolate",
+    "effects": ["intense_heat", "fire_tornadoes"]
+  },
+  "248": {
+    "name": "Vindemitarix Prime",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "249": {
+    "name": "X-45",
+    "biome": "swamp",
+    "effects": ["thick_fog"]
+  },
+  "250": {
+    "name": "Yed Prior",
+    "biome": "crimsonmoor",
+    "effects": ["ion_storms"]
+  },
+  "251": {
+    "name": "Zefia",
+    "biome": "ethereal",
+    "effects": ["none"]
+  },
+  "252": {
+    "name": "Zosma",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "253": {
+    "name": "Zzaniah Prime",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "254": {
+    "name": "Skitter",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "255": {
+    "name": "Euphoria III",
+    "biome": "moon",
+    "effects": ["extreme_cold", "meteor_storms"]
+  },
+  "256": {
+    "name": "Diaspora X",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "257": {
+    "name": "Gemstone Bluffs",
+    "biome": "highlands",
+    "effects": ["thick_fog", "rainstorms"]
+  },
+  "258": {
+    "name": "Zagon Prime",
+    "biome": "mesa",
+    "effects": ["intense_heat", "sandstorms"]
+  },
+  "259": {
+    "name": "Omicron",
+    "biome": "tundra",
+    "effects": ["none"]
+  },
+  "260": {
+    "name": "Cyberstan",
+    "biome": "icemoss_special",
+    "effects": ["tremors"]
+  }
 }


### PR DESCRIPTION
## Description

This PR introduces some new models to the API. Both new models come with their respective fields on the `Planet` model as well as their own endpoints:

#### Effects

- `/api/biomes`: Get a list of all biomes.
- `/api/biomes/:id`: Get a biome by id.
- `/api/biomes/:id/planets`: Get the planets matching a specific biome.

#### Biomes

- `/api/effects`: Get a list of all environmental effects.
- `/api/effects/:id`: Get a environmental effect by id.
- `/api/effects/:id/planets`: Get the planets matching a specific environmental effect.

The interactive [postman collection](https://documenter.getpostman.com/view/33840175/2sA35Bd54w) has already been updated.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
