### PR TITLE
feat: add planet texture images in webp format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ env:
   HISTORY_API_URL: "https://helldivers-b.omnedia.com/api"
   API_URL: "https://api.live.prod.thehelldiversgame.com/api"
   # stratagem setup
-  STRATAGEM_IMAGE_URL: "https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"
+  STORAGE_URL: "https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public"
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV RATE_LIMIT="200"
 ENV DATABASE_URL="file:./database/data.db"
 ENV HISTORY_API_URL="https://helldivers-b.omnedia.com/api"
 ENV API_URL="https://api.live.prod.thehelldiversgame.com/api"
-ENV STRATAGEM_IMAGE_URL="https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public/stratagems"
+ENV STORAGE_URL="https://vxspqnuarwhjjbxzgauv.supabase.co/storage/v1/object/public"
 
 # install dependencies into temp directory
 # this will cache them and speed up future builds

--- a/prisma/migrations/20240422103412_textures/migration.sql
+++ b/prisma/migrations/20240422103412_textures/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - Added the required column `imageUrl` to the `Planet` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Planet" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "index" BIGINT NOT NULL,
+    "name" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "sectorId" INTEGER NOT NULL,
+    "health" INTEGER NOT NULL,
+    "maxHealth" INTEGER NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "players" INTEGER NOT NULL,
+    "disabled" BOOLEAN NOT NULL,
+    "regeneration" INTEGER NOT NULL,
+    "liberation" REAL NOT NULL,
+    "liberationRate" REAL NOT NULL,
+    "liberationState" TEXT NOT NULL,
+    "initialOwnerId" INTEGER NOT NULL,
+    "positionX" REAL NOT NULL,
+    "positionY" REAL NOT NULL,
+    "globalEventId" INTEGER,
+    "biomeId" INTEGER NOT NULL,
+    "statisticId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Planet_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_sectorId_fkey" FOREIGN KEY ("sectorId") REFERENCES "Sector" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_initialOwnerId_fkey" FOREIGN KEY ("initialOwnerId") REFERENCES "Faction" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_globalEventId_fkey" FOREIGN KEY ("globalEventId") REFERENCES "GlobalEvent" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Planet_biomeId_fkey" FOREIGN KEY ("biomeId") REFERENCES "Biome" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Planet_statisticId_fkey" FOREIGN KEY ("statisticId") REFERENCES "Stats" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Planet" ("biomeId", "createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "liberation", "liberationRate", "liberationState", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt") SELECT "biomeId", "createdAt", "disabled", "globalEventId", "health", "id", "index", "initialOwnerId", "liberation", "liberationRate", "liberationState", "maxHealth", "name", "ownerId", "players", "positionX", "positionY", "regeneration", "sectorId", "statisticId", "updatedAt" FROM "Planet";
+DROP TABLE "Planet";
+ALTER TABLE "new_Planet" RENAME TO "Planet";
+CREATE UNIQUE INDEX "Planet_index_key" ON "Planet"("index");
+CREATE UNIQUE INDEX "Planet_statisticId_key" ON "Planet"("statisticId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Planet {
   sectorId        Int
   health          Int
   maxHealth       Int
+  imageUrl        String
   players         Int
   disabled        Boolean
   regeneration    Int

--- a/src/controllers/stratagems.ts
+++ b/src/controllers/stratagems.ts
@@ -30,7 +30,10 @@ export const getStratagemById = await witCache(async (ctx: Context) => {
     }
 
     // slightly transform the data
-    const imageBaseUrl = process.env.STRATAGEM_IMAGE_URL || "";
+    const imageBaseUrl = process.env.STORAGE_URL
+      ? `/${process.env.STORAGE_URL}/stratagems`
+      : "";
+
     stratagem.imageUrl = `${imageBaseUrl}${stratagem.imageUrl}`;
     (stratagem as any).keys = stratagem.keys.split(",");
 
@@ -57,7 +60,10 @@ export const getAllStratagems = await witCache(async (ctx: Context) => {
     return ctx.json({
       data: stratagems.map(stratagem => {
         // slightly transform the data
-        const imageBaseUrl = process.env.STRATAGEM_IMAGE_URL || "";
+        const imageBaseUrl = process.env.STORAGE_URL
+          ? `/${process.env.STORAGE_URL}/stratagems`
+          : "";
+
         stratagem.imageUrl = `${imageBaseUrl}${stratagem.imageUrl}`;
         (stratagem as any).keys = stratagem.keys.split(",");
         return stratagem;

--- a/src/controllers/stratagems.ts
+++ b/src/controllers/stratagems.ts
@@ -31,7 +31,7 @@ export const getStratagemById = await witCache(async (ctx: Context) => {
 
     // slightly transform the data
     const imageBaseUrl = process.env.STORAGE_URL
-      ? `/${process.env.STORAGE_URL}/stratagems`
+      ? `${process.env.STORAGE_URL}/stratagems`
       : "";
 
     stratagem.imageUrl = `${imageBaseUrl}${stratagem.imageUrl}`;
@@ -61,7 +61,7 @@ export const getAllStratagems = await witCache(async (ctx: Context) => {
       data: stratagems.map(stratagem => {
         // slightly transform the data
         const imageBaseUrl = process.env.STORAGE_URL
-          ? `/${process.env.STORAGE_URL}/stratagems`
+          ? `${process.env.STORAGE_URL}/stratagems`
           : "";
 
         stratagem.imageUrl = `${imageBaseUrl}${stratagem.imageUrl}`;

--- a/src/static/json/planets.json
+++ b/src/static/json/planets.json
@@ -2,7 +2,8 @@
   "0": {
     "name": "Super Earth",
     "biome": "unknown",
-    "effects": ["none"]
+    "effects": ["none"],
+    "imageName": "superearth"
   },
   "1": {
     "name": "Klen Dahth II",
@@ -1197,7 +1198,8 @@
   "239": {
     "name": "Tien Kwan",
     "biome": "icemoss_special",
-    "effects": ["extreme_cold", "meteor_storms"]
+    "effects": ["extreme_cold", "meteor_storms"],
+    "imageName": "tienkwan"
   },
   "240": {
     "name": "Troost",
@@ -1302,6 +1304,7 @@
   "260": {
     "name": "Cyberstan",
     "biome": "icemoss_special",
-    "effects": ["tremors"]
+    "effects": ["tremors"],
+    "imageName": "cyberstan"
   }
 }

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -24,6 +24,7 @@ export interface PlanetEntry {
   name: string;
   index: number;
   biome: string;
+  imageName: string;
   effects: string[];
 }
 
@@ -47,7 +48,7 @@ export interface EffectEntry extends BiomeEntry {}
 export async function prepareForSourceData() {
   const [factions, planets, sectors, biomes, effects]: [
     NameEntry[],
-    Array<NameEntry & { biome: string; effects: string[] }>,
+    Array<NameEntry & { imageUrl: string; biome: string; effects: string[] }>,
     SectorEntry[],
     Array<Omit<NameEntry, "index"> & { index: string; description: string }>,
     Array<Omit<NameEntry, "index"> & { index: string; description: string }>,
@@ -106,7 +107,18 @@ export async function prepareForSourceData() {
 
   // populate planets
   for (const key in planetsJSON) {
-    planets.push({ ...planetsJSON[key], index: parseInt(key) });
+    const entry = planetsJSON[key];
+    const folder = entry.imageName ? "unique" : "biome";
+    const file = `${entry.imageName ?? entry.biome}.webp`;
+    const baseImageUrl = process.env.STORAGE_URL
+      ? `${process.env.STORAGE_URL}`
+      : "";
+
+    planets.push({
+      ...planetsJSON[key],
+      index: parseInt(key),
+      imageUrl: `${baseImageUrl}/planets/${folder}/${file}`,
+    });
   }
 
   // populate sectors
@@ -412,6 +424,7 @@ export async function transformAndStoreSourceData() {
         disabled: info.disabled,
         players: status.players,
         maxHealth: info.maxHealth,
+        imageUrl: planet.imageUrl,
         positionX: info.position.x,
         positionY: info.position.y,
         regeneration: status.regenPerSecond,


### PR DESCRIPTION
## Description

This PR introduces the `imageUrl` field on the `Planet` model. This field contains a link to a webp containg the planets texture when viewed on the galactic map as celestial body.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
