### PR TITLE
fix: replace broken status badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
   <a href="https://github.com/hellhub-collective/api/actions/workflows/github-code-scanning/codeql">
     <img src="https://github.com/hellhub-collective/api/actions/workflows/github-code-scanning/codeql/badge.svg" alt="CodeQL" />
   </a>
-  <a href="https://github.com/hellhub-collective/api/actions/workflows/tests.yml">
-    <img src="https://github.com/hellhub-collective/api/actions/workflows/tests.yml/badge.svg" alt="Tests" />
+  <a href="https://github.com/hellhub-collective/api/releases/latest">
+    <img src="https://img.shields.io/github/v/release/hellhub-collective/api" alt="Latest release" />
   </a>
 </p>
 


### PR DESCRIPTION
## Description

This PR replaces the broken tests badge. The unit test action was removed in the last release because the docker build action already executes the tests inside the deployment environment.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
